### PR TITLE
Mission Control V5: mobile-first, AI-powered control panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
 # Environment variables for Mission Control
 PORT=3000
 WORKSPACE_ROOT=
+MC_PUSH_TOKEN=
+
+# AI Summary (optional — falls back to template-based summaries)
+MC_AI_KEY=
+MC_AI_MODEL=gemini-2.5-flash
+MC_AI_PROVIDER=google

--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@ PORT=3000
 WORKSPACE_ROOT=
 MC_PUSH_TOKEN=
 
+# Nudge transport (optional — nudge UI hidden until configured)
+# Set to a webhook URL that Mansa can receive (e.g. Discord webhook, OpenClaw API)
+MC_NUDGE_ENDPOINT=
+
 # AI Summary (optional — falls back to template-based summaries)
 MC_AI_KEY=
 MC_AI_MODEL=gemini-2.5-flash

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mission Control v2 MVP
+# Mission Control v5
 
 Fast, file-backed operator console MVP.
 

--- a/app.js
+++ b/app.js
@@ -1,24 +1,14 @@
+// Mission Control V5 — mobile-first, AI-powered, actionable
 const VIEW_DEFS = [
-  { key: 'overview', label: 'Overview', icon: '◈', group: 'Console' },
-  { key: 'work', label: 'Work', icon: '☐', group: 'Console' },
-  { key: 'approvals', label: 'Approvals', icon: '✓', group: 'Console' },
-  { key: 'events', label: 'Events', icon: '⊙', group: 'Operations' },
-  { key: 'agents', label: 'Agents', icon: '⊕', group: 'Operations' },
-  { key: 'schedule', label: 'Schedule', icon: '◷', group: 'Operations' },
-  { key: 'usage-cost', label: 'Usage / Cost', icon: '$', group: 'Operations' },
-  { key: 'artifacts', label: 'Artifacts', icon: '◫', group: 'System' },
-  { key: 'intel', label: 'Intel', icon: '◉', group: 'System' }
+  { key: 'home', label: 'Home', icon: '◈' },
+  { key: 'work', label: 'Work', icon: '☐' },
+  { key: 'activity', label: 'Activity', icon: '⊙' },
+  { key: 'agents', label: 'Agents', icon: '⊕' },
+  { key: 'settings', label: 'Settings', icon: '⚙' }
 ];
 
 const LANE_ORDER = ['now', 'next', 'blocked', 'backlog', 'icebox', 'done_verified'];
-const LANE_LABELS = {
-  now: 'Now / Attack',
-  next: 'Next Up',
-  blocked: 'Blocked',
-  backlog: 'Backlog',
-  icebox: 'Icebox / Research',
-  done_verified: 'Done / Verified'
-};
+const LANE_LABELS = { now: 'Now / Attack', next: 'Next Up', blocked: 'Blocked', backlog: 'Backlog', icebox: 'Icebox / Research', done_verified: 'Done / Verified' };
 
 const app = document.getElementById('app');
 const nav = document.getElementById('nav');
@@ -30,69 +20,58 @@ const lastRefreshedEl = document.getElementById('last-refreshed');
 const openAlertsEl = document.getElementById('open-alerts-pill');
 
 let state = null;
-let currentView = location.hash.replace('#', '') || 'overview';
+let currentView = location.hash.replace('#', '') || 'home';
+// Migrate old hash
+if (['overview', 'approvals', 'events', 'schedule', 'usage-cost', 'artifacts', 'intel'].includes(currentView)) {
+  if (currentView === 'overview') currentView = 'home';
+  else if (['events', 'artifacts', 'intel'].includes(currentView)) currentView = 'activity';
+  else if (['schedule', 'usage-cost'].includes(currentView)) currentView = 'settings';
+  else if (currentView === 'approvals') currentView = 'home';
+}
 let refreshInterval = null;
 let activeKanbanLane = 'now';
 let commitmentCountdownInterval = null;
+let aiSummary = null;
+let aiSummaryStateKey = null;
+let activeActivityTab = 'all';
+let activeSettingsTab = 'spend';
+let snoozedProblems = {};
+
+// Load snoozed problems from localStorage
+try { snoozedProblems = JSON.parse(localStorage.getItem('mc_snoozed_problems') || '{}'); } catch { snoozedProblems = {}; }
+function saveSnoozed() { localStorage.setItem('mc_snoozed_problems', JSON.stringify(snoozedProblems)); }
+function isProblemSnoozed(id) { const until = snoozedProblems[id]; if (!until) return false; if (Date.now() > until) { delete snoozedProblems[id]; saveSnoozed(); return false; } return true; }
 
 function escapeHtml(value = '') {
-  return String(value)
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;');
+  return String(value).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;').replaceAll("'", '&#39;');
 }
-
-function humanize(value = '') {
-  return String(value).replaceAll('_', ' ').replaceAll('/', ' ').replace(/\s+/g, ' ').trim();
-}
-
-function titleCase(value = '') {
-  return humanize(value).replace(/\w/g, (char) => char.toUpperCase());
-}
-
-function formatDateTime(value) {
-  if (!value) return '—';
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return '—';
-  return date.toLocaleString([], { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
-}
-
-function formatTime(value) {
-  if (!value) return '—';
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return '—';
-  return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', second: '2-digit' });
-}
-
+function humanize(value = '') { return String(value).replaceAll('_', ' ').replaceAll('/', ' ').replace(/\s+/g, ' ').trim(); }
+function titleCase(value = '') { return humanize(value).replace(/\w/g, (c) => c.toUpperCase()); }
+function formatDateTime(value) { if (!value) return '—'; const d = new Date(value); if (Number.isNaN(d.getTime())) return '—'; return d.toLocaleString([], { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }); }
+function formatTime(value) { if (!value) return '—'; const d = new Date(value); if (Number.isNaN(d.getTime())) return '—'; return d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit', second: '2-digit' }); }
 function formatRelative(value) {
   if (!value) return '—';
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return '—';
-  const diffMs = Date.now() - date.getTime();
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return '—';
+  const diffMs = Date.now() - d.getTime();
   const absSec = Math.round(Math.abs(diffMs) / 1000);
   const buckets = [['day', 86400], ['hour', 3600], ['minute', 60]];
   for (const [unit, size] of buckets) {
-    if (absSec >= size) {
-      const valueNum = Math.round(diffMs / 1000 / size);
-      return new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' }).format(-valueNum, unit);
-    }
+    if (absSec >= size) { const v = Math.round(diffMs / 1000 / size); return new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' }).format(-v, unit); }
   }
   return 'just now';
 }
-
-function money(value) {
-  return `$${Number(value || 0).toFixed(2)}`;
+function formatTimelineTime(value) {
+  if (!value) return '—';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return '—';
+  const now = new Date();
+  const isToday = d.toDateString() === now.toDateString();
+  if (isToday) return d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  return d.toLocaleString([], { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
 }
-
-function duration(value) {
-  const ms = Number(value || 0);
-  if (!ms) return '—';
-  if (ms < 1000) return `${ms}ms`;
-  if (ms < 60000) return `${(ms / 1000).toFixed(ms < 10000 ? 1 : 0)}s`;
-  return `${Math.round(ms / 60000)}m`;
-}
+function money(value) { return `$${Number(value || 0).toFixed(2)}`; }
+function duration(value) { const ms = Number(value || 0); if (!ms) return '—'; if (ms < 1000) return `${ms}ms`; if (ms < 60000) return `${(ms / 1000).toFixed(ms < 10000 ? 1 : 0)}s`; return `${Math.round(ms / 60000)}m`; }
 
 function badgeTone(value = '') {
   const lower = String(value).toLowerCase();
@@ -102,36 +81,527 @@ function badgeTone(value = '') {
   if (['info', 'claimed', 'idle', 'backlog', 'in_progress', 'operating_normally', 'ok', 'needs_attention', 'cancelled'].includes(lower)) return 'info';
   return 'default';
 }
-
-function badge(label, customText = null) {
-  return `<span class="badge badge-${badgeTone(label)}">${escapeHtml(customText || humanize(label))}</span>`;
-}
-
+function badge(label, customText = null) { return `<span class="badge badge-${badgeTone(label)}">${escapeHtml(customText || humanize(label))}</span>`; }
 function truthStateClass(item) { return `truth-${item?._truth?.state || 'unknown'}`; }
 function truthDot(item) { return `<span class="truth-dot ${truthStateClass(item)}"></span>`; }
-function truthBadge(item) {
-  const state = item?._truth?.state || 'unknown';
-  return `<span class="badge badge-${badgeTone(state)}">${truthDot(item)}${escapeHtml(state)}</span>`;
-}
+function truthBadge(item) { const s = item?._truth?.state || 'unknown'; return `<span class="badge badge-${badgeTone(s)}">${truthDot(item)}${escapeHtml(s)}</span>`; }
 function important(text) { return `<span class="table-strong">${escapeHtml(text ?? '—')}</span>`; }
-function getViewLabel(key) { return VIEW_DEFS.find((view) => view.key === key)?.label || 'Overview'; }
-function getOpenAlerts() { return (state?.alerts || []).filter((alert) => String(alert.status).toLowerCase() === 'open'); }
-function getPendingApprovals() { return (state?.approvals || []).filter((approval) => String(approval.status).toLowerCase() === 'pending'); }
-function getLaneSummaryMap() { const map = new Map(); (state?.overview?.laneSummaries || []).forEach((item) => map.set(item.lane, item.count)); return map; }
+function getViewLabel(key) { return VIEW_DEFS.find((v) => v.key === key)?.label || 'Home'; }
+function getOpenAlerts() { return (state?.alerts || []).filter((a) => String(a.status).toLowerCase() === 'open'); }
+function getPendingApprovals() { return (state?.approvals || []).filter((a) => String(a.status).toLowerCase() === 'pending'); }
+function getLaneSummaryMap() { const m = new Map(); (state?.overview?.laneSummaries || []).forEach((i) => m.set(i.lane, i.count)); return m; }
 function navigateTo(view) { currentView = view; location.hash = view; draw(); }
 
+function getNeedsMeCount() {
+  return getPendingApprovals().length + (state?.tasks || []).filter((t) => t.status === 'waiting_for_human').length;
+}
+
+function getGreeting() {
+  const h = new Date().getHours();
+  if (h < 12) return 'Good morning, Ahmed.';
+  if (h < 17) return 'Good afternoon, Ahmed.';
+  return 'Good evening, Ahmed.';
+}
+
+function getStatusBannerState() {
+  const agent = state?.agents?.[0];
+  const approvals = getPendingApprovals().length;
+  const waitingTasks = (state?.tasks || []).filter((t) => t.status === 'waiting_for_human').length;
+  const commitments = state?.commitments || [];
+  const atRisk = commitments.filter((c) => c.status === 'at_risk').length;
+  const missed = commitments.filter((c) => c.status === 'missed').length;
+  const heartbeatAgeMs = agent?.lastHeartbeatAt ? Date.now() - new Date(agent.lastHeartbeatAt).getTime() : Number.POSITIVE_INFINITY;
+  if (!agent?.lastHeartbeatAt || heartbeatAgeMs > 2 * 60 * 60 * 1000) return 'offline';
+  if (missed || getOpenAlerts().some((a) => String(a.severity).toLowerCase() === 'critical') || heartbeatAgeMs > 30 * 60 * 1000) return 'stalled';
+  if (approvals || waitingTasks || atRisk || heartbeatAgeMs > 10 * 60 * 1000) return 'attention';
+  return 'ok';
+}
+
+function formatStatusLabel(key) {
+  return ({ ok: 'All systems nominal', attention: 'Needs attention', stalled: 'Stalled', offline: 'Offline' })[key] || 'All systems nominal';
+}
+
+function statusDotChar(key) {
+  return ({ ok: '🟢', attention: '🟡', stalled: '🔴', offline: '⚫' })[key] || '🟢';
+}
+
+// --- Render Nav ---
 function renderNav() {
-  const groups = [...new Set(VIEW_DEFS.map((view) => view.group))];
-  nav.innerHTML = groups.map((group) => {
-    const items = VIEW_DEFS.filter((view) => view.group === group).map((view) => `
-      <button class="nav-item ${view.key === currentView ? 'is-active' : ''}" type="button" data-view="${view.key}">
-        <span class="nav-icon">${view.icon}</span>
-        <span>${view.label}</span>
+  const needsMe = getNeedsMeCount();
+  nav.innerHTML = VIEW_DEFS.map((v) => `
+    <button class="nav-item ${v.key === currentView ? 'is-active' : ''}" type="button" data-view="${v.key}">
+      <span class="nav-icon">${v.icon}</span>
+      <span>${v.label}</span>
+      ${v.key === 'home' && needsMe > 0 ? '<span class="nav-dot"></span>' : ''}
+    </button>
+  `).join('');
+  nav.querySelectorAll('[data-view]').forEach((btn) => btn.addEventListener('click', () => navigateTo(btn.dataset.view)));
+}
+
+// --- AI Summary Hero ---
+function renderAISummaryHero() {
+  const stateKey = getStatusBannerState();
+  const summaryText = aiSummary || null;
+  const lastUpdate = state?.meta?.generatedAt ? formatRelative(state.meta.generatedAt) : '—';
+
+  return `
+    <section class="v5-hero v5-hero--${stateKey}">
+      <div class="v5-hero__greeting">${escapeHtml(getGreeting())}</div>
+      <div class="v5-hero__summary" id="ai-summary-text">
+        ${summaryText ? escapeHtml(summaryText) : '<div class="skeleton-line"></div><div class="skeleton-line skeleton-line--short"></div>'}
+      </div>
+      <div class="v5-hero__status">
+        <span>${statusDotChar(stateKey)} ${escapeHtml(formatStatusLabel(stateKey))}</span>
+      </div>
+      <div class="v5-hero__meta">Last update: ${escapeHtml(lastUpdate)}</div>
+    </section>
+  `;
+}
+
+// --- KPI Row ---
+function renderKpiRow() {
+  const overview = state?.overview || {};
+  const needsMe = getNeedsMeCount();
+  const confidence = computeDataConfidence(overview.dataQuality || {});
+  return `
+    <section class="v5-kpi-row">
+      <button class="v5-kpi" type="button" data-nav-view="work">
+        <span class="v5-kpi__value">${overview.tasksInProgress ?? 0}</span>
+        <span class="v5-kpi__label">ACTIVE</span>
       </button>
+      <button class="v5-kpi ${needsMe > 0 ? 'v5-kpi--attention' : ''}" type="button" data-nav-view="home">
+        <span class="v5-kpi__value ${needsMe > 0 ? 'needs-me-active' : ''}">${needsMe}</span>
+        <span class="v5-kpi__label">NEEDS ME</span>
+      </button>
+      <button class="v5-kpi" type="button" data-nav-view="settings">
+        <span class="v5-kpi__value v5-kpi__value--money">${money(overview.spendTodayUsd ?? 0)}</span>
+        <span class="v5-kpi__label">TODAY</span>
+      </button>
+      <button class="v5-kpi" type="button" data-nav-view="settings">
+        <span class="v5-kpi__value">${confidence}%</span>
+        <span class="v5-kpi__label">DATA</span>
+      </button>
+    </section>
+  `;
+}
+
+function computeDataConfidence(dq = {}) {
+  const total = Object.values(dq).reduce((s, v) => s + Number(v || 0), 0);
+  if (!total) return 0;
+  return Math.round(((Number(dq.verified || 0)) / total) * 100);
+}
+
+// --- Commitments Widget ---
+function getCommitmentTimeContext(c) {
+  const due = c?.dueBy ? new Date(c.dueBy).getTime() : null;
+  const resolved = c?.resolvedAt ? new Date(c.resolvedAt).getTime() : null;
+  if (!due) return 'No deadline';
+  const deltaMs = (resolved || Date.now()) - due;
+  const absMin = Math.round(Math.abs(deltaMs) / 60000);
+  const hrs = Math.floor(absMin / 60);
+  const mins = absMin % 60;
+  const span = hrs ? `${hrs}h ${mins}m` : `${mins}min`;
+  if (c.status === 'delivered') return deltaMs <= 0 ? `${span} early` : `${span} late`;
+  if (c.status === 'missed') return `overdue by ${span}`;
+  if (c.status === 'at_risk' || c.status === 'in_progress') return `${span} remaining`;
+  return c.proof ? `✓ ${c.proof}` : 'Cancelled';
+}
+
+function commitmentStatusIcon(status) {
+  return ({ delivered: '✓', missed: '✗', at_risk: '⏱', in_progress: '●', cancelled: '—' })[status] || '●';
+}
+
+function renderCommitmentsWidget() {
+  const commitments = [...(state?.commitments || [])].sort((a, b) => new Date(b.madeAt || 0) - new Date(a.madeAt || 0));
+  if (!commitments.length) return '';
+  const stats = state?.overview?.commitmentStats || {};
+  const delivered = stats.delivered || 0;
+  const total = stats.commitmentsMade || 0;
+  const deliveryRate = total ? Math.round(delivered / total * 100) : 0;
+
+  return `
+    <section class="v5-section">
+      <div class="v5-section__header">
+        <span class="v5-section__title">COMMITMENTS</span>
+        <span class="v5-section__stat">${delivered}/${total} shipped</span>
+      </div>
+      <div class="v5-commitment-list">
+        ${commitments.map((c) => `
+          <div class="v5-commitment-row v5-commitment-row--${escapeHtml(c.status || 'in_progress')}" data-commitment-id="${escapeHtml(c.id || '')}" data-commitment-due-by="${escapeHtml(c.dueBy || '')}" data-commitment-status="${escapeHtml(c.status || 'in_progress')}" data-commitment-resolved-at="${escapeHtml(c.resolvedAt || '')}">
+            <div class="v5-commitment-row__main" role="button" tabindex="0">
+              <span class="v5-commitment-icon v5-commitment-icon--${escapeHtml(c.status || 'in_progress')}">${commitmentStatusIcon(c.status)}</span>
+              <span class="v5-commitment-title">${escapeHtml(c.title || 'Untitled')}</span>
+              <span class="v5-commitment-time">${escapeHtml(getCommitmentTimeContext(c))}</span>
+            </div>
+            <div class="v5-commitment-detail" hidden>
+              <div class="v5-commitment-context">${escapeHtml(c.context || 'No context recorded')}</div>
+              ${c.proof ? `<div class="v5-commitment-proof">Proof: ${escapeHtml(c.proof)}</div>` : ''}
+              <div class="v5-commitment-dates">Made: ${escapeHtml(formatDateTime(c.madeAt))} · Due: ${escapeHtml(formatDateTime(c.dueBy))}${c.resolvedAt ? ` · Resolved: ${escapeHtml(formatDateTime(c.resolvedAt))}` : ''}</div>
+              <div class="v5-commitment-actions">
+                ${c.status === 'in_progress' ? `<button class="btn btn-secondary btn-sm" type="button" data-nudge-type="deadline_extension" data-nudge-target="${escapeHtml(c.id || '')}">Extend deadline</button>` : ''}
+                ${c.status === 'at_risk' ? `<button class="btn btn-secondary btn-sm" type="button" data-nudge-type="priority_change" data-nudge-target="${escapeHtml(c.id || '')}">I'll handle it</button>` : ''}
+                ${c.status === 'missed' ? `<button class="btn btn-secondary btn-sm" type="button" data-nudge-type="instruction" data-nudge-target="${escapeHtml(c.id || '')}" data-nudge-message="Acknowledged">Acknowledged</button>` : ''}
+              </div>
+            </div>
+          </div>
+        `).join('')}
+      </div>
+      <div class="v5-section__footer-stats">
+        <span>Delivery rate: ${deliveryRate}%</span>
+        <span>Avg: ${escapeHtml(stats.avgDeliveryLead || '—')}</span>
+      </div>
+    </section>
+  `;
+}
+
+// --- Active Work ---
+function renderActiveWork() {
+  const tasks = (state?.tasks || []).filter((t) => t.lane === 'now').slice(0, 5);
+  const totalNow = (state?.tasks || []).filter((t) => t.lane === 'now').length;
+
+  return `
+    <section class="v5-section">
+      <div class="v5-section__header">
+        <span class="v5-section__title">ACTIVE WORK</span>
+      </div>
+      ${tasks.length ? `<div class="v5-work-list">${tasks.map((t) => `
+        <div class="v5-work-item">
+          <div class="v5-work-item__main">
+            <span class="v5-work-dot"></span>
+            <span class="v5-work-title">${escapeHtml(t.title || 'Untitled')}</span>
+          </div>
+          <div class="v5-work-meta">${escapeHtml(t.project || 'general')} · ${escapeHtml(humanize(t.status || 'in progress'))}</div>
+          <button class="btn btn-secondary btn-sm v5-nudge-inline" type="button" data-nudge-type="status_request" data-nudge-target="${escapeHtml(t.id || '')}" data-nudge-message="What's the status on this?">Ask for update</button>
+        </div>
+      `).join('')}</div>` : '<div class="v5-empty">No active tasks</div>'}
+      ${totalNow > 5 ? `<div class="v5-more">and ${totalNow - 5} more</div>` : ''}
+      <div class="section-footer"><button type="button" class="link-button" data-nav-view="work">View all work →</button></div>
+    </section>
+  `;
+}
+
+// --- Needs Your Attention (merged problems + approvals) ---
+function renderNeedsAttention() {
+  const approvals = getPendingApprovals();
+  const problems = getOpenAlerts().filter((a) => !isProblemSnoozed(a.id));
+  // Sort: critical first, then warnings, then approvals
+  const criticalProblems = problems.filter((p) => String(p.severity).toLowerCase() === 'critical');
+  const warningProblems = problems.filter((p) => String(p.severity).toLowerCase() === 'warning');
+  const infoProblems = problems.filter((p) => !['critical', 'warning'].includes(String(p.severity).toLowerCase()));
+  const merged = [...criticalProblems, ...warningProblems, ...approvals.map((a) => ({ ...a, _isApproval: true })), ...infoProblems];
+
+  if (!merged.length) return '';
+
+  const displayed = merged.slice(0, 5);
+  const remaining = merged.length - displayed.length;
+
+  return `
+    <section class="v5-section v5-attention">
+      <div class="v5-section__header">
+        <span class="v5-section__title">NEEDS YOUR ATTENTION</span>
+        <span class="v5-section__stat">${merged.length} item${merged.length === 1 ? '' : 's'}</span>
+      </div>
+      <div class="v5-attention-list">
+        ${displayed.map((item) => {
+          if (item._isApproval) {
+            return `
+              <div class="v5-attention-item" data-approval-id="${escapeHtml(item.id)}">
+                <div class="v5-attention-item__header">
+                  <span class="v5-attention-dot v5-attention-dot--warning">🟡</span>
+                  <span class="v5-attention-item__title">${escapeHtml(item.title || item.id)}</span>
+                </div>
+                <div class="v5-attention-item__desc">${escapeHtml(item.reason || 'Pending approval')}</div>
+                <div class="v5-attention-actions">
+                  <button class="btn btn-success btn-sm" type="button" data-approval-action="approved" data-approval-id="${escapeHtml(item.id)}">Approve</button>
+                  <button class="btn btn-destructive btn-sm" type="button" data-approval-action="rejected" data-approval-id="${escapeHtml(item.id)}">Reject</button>
+                  <button class="btn btn-secondary btn-sm v5-notes-toggle" type="button">Notes</button>
+                </div>
+                <div class="v5-notes-form" hidden>
+                  <input class="v5-notes-input" type="text" placeholder="Optional notes..." />
+                </div>
+                <div class="confirmation-slot"></div>
+              </div>
+            `;
+          }
+          const severityDot = String(item.severity).toLowerCase() === 'critical' ? '🔴' : '🟡';
+          return `
+            <div class="v5-attention-item v5-attention-item--problem" data-problem-id="${escapeHtml(item.id)}">
+              <div class="v5-attention-item__header" role="button" tabindex="0">
+                <span class="v5-attention-dot">${severityDot}</span>
+                <span class="v5-attention-item__title">${escapeHtml(item.title || 'Untitled')}</span>
+              </div>
+              <div class="v5-attention-item__desc">${escapeHtml(item.description || 'No details')}</div>
+              <div class="v5-attention-detail" hidden>
+                <div class="v5-attention-recommend">→ ${escapeHtml(item.recommendedAction || 'Review and respond.')}</div>
+              </div>
+              <div class="v5-attention-actions">
+                <button class="btn btn-secondary btn-sm" type="button" data-snooze-id="${escapeHtml(item.id)}">Snooze 24h</button>
+                ${String(item.severity).toLowerCase() === 'critical' ? `<button class="btn btn-secondary btn-sm" type="button" data-nudge-type="priority_change" data-nudge-target="${escapeHtml(item.id)}" data-nudge-message="Prioritize this problem">Prioritize this</button>` : ''}
+              </div>
+            </div>
+          `;
+        }).join('')}
+      </div>
+      ${remaining > 0 ? `<div class="v5-more">and ${remaining} more</div>` : ''}
+    </section>
+  `;
+}
+
+// --- Activity Timeline (Home) ---
+function renderHomeTimeline() {
+  const events = [...(state?.events || [])].sort((a, b) => new Date(b.timestamp || 0) - new Date(a.timestamp || 0)).slice(0, 6);
+  if (!events.length) return '';
+
+  // Group by day
+  const today = new Date().toDateString();
+  let lastDateGroup = null;
+
+  return `
+    <section class="v5-section">
+      <div class="v5-section__header">
+        <span class="v5-section__title">TODAY</span>
+      </div>
+      <div class="v5-timeline">
+        ${events.map((e) => {
+          const eDate = new Date(e.timestamp).toDateString();
+          let separator = '';
+          if (eDate !== lastDateGroup && eDate !== today) {
+            separator = `<div class="v5-timeline-separator">YESTERDAY</div>`;
+          }
+          lastDateGroup = eDate;
+          const icon = e.verificationState === 'verified' ? '✓' : e.type === 'session_memory_captured' ? '📎' : (e.status === 'warning' ? '⚠' : '●');
+          return `${separator}
+            <div class="v5-timeline-row">
+              <span class="v5-timeline-time">${escapeHtml(formatTimelineTime(e.timestamp))}</span>
+              <span class="v5-timeline-summary">${escapeHtml(e.summary || 'Untitled event')}</span>
+              <span class="v5-timeline-icon">${icon}</span>
+            </div>`;
+        }).join('')}
+      </div>
+      <div class="section-footer"><button type="button" class="link-button" data-nav-view="activity">View full timeline →</button></div>
+    </section>
+  `;
+}
+
+// --- Morning Digest ---
+function renderMorningDigest() {
+  const lastVisit = Number(localStorage.getItem('mc_last_visit') || 0);
+  const now = Date.now();
+  const hoursSince = (now - lastVisit) / (1000 * 60 * 60);
+  if (lastVisit && hoursSince < 8) return '';
+
+  const events = state?.events || [];
+  const commitments = state?.commitments || [];
+  const usage = state?.usage || [];
+  const today = new Date().toISOString().slice(0, 10);
+  const recentTasks = (state?.tasks || []).filter(t => t.status === 'done_verified').length;
+  const recentCommitments = commitments.filter(c => c.status === 'delivered').length;
+  const blockers = getOpenAlerts().filter(a => String(a.severity).toLowerCase() === 'critical').length;
+  const spend = usage.filter(r => String(r.timestamp || '').startsWith(today)).reduce((s, r) => s + Number(r.estimatedCostUsd || 0), 0);
+
+  if (!events.length && !recentTasks && !recentCommitments) return '';
+
+  const bullets = [];
+  if (recentTasks) bullets.push(`${recentTasks} tasks completed`);
+  if (recentCommitments) bullets.push(`${recentCommitments} commitments delivered`);
+  if (blockers) bullets.push(`${blockers} new blocker${blockers === 1 ? '' : 's'}`);
+  if (spend > 0) bullets.push(`${money(spend)} spent`);
+
+  const summary = !bullets.length ? 'Quiet night — no new items need your attention.' :
+    `While you were away, Mansa completed ${recentTasks} task${recentTasks === 1 ? '' : 's'} and shipped ${recentCommitments} commitment${recentCommitments === 1 ? '' : 's'}.${blockers ? ` ${blockers} blocker${blockers === 1 ? '' : 's'} appeared that need${blockers === 1 ? 's' : ''} your attention.` : ''} Total spend: ${money(spend)}.`;
+
+  return `
+    <section class="v5-digest" id="morning-digest">
+      <div class="v5-digest__header">☀ OVERNIGHT DIGEST</div>
+      <div class="v5-digest__summary">${escapeHtml(summary)}</div>
+      <ul class="v5-digest__bullets">
+        ${bullets.map(b => `<li>▸ ${escapeHtml(b)}</li>`).join('')}
+      </ul>
+      <div class="v5-digest__action">
+        <button class="btn btn-secondary btn-sm" type="button" id="dismiss-digest">Got it →</button>
+      </div>
+    </section>
+  `;
+}
+
+// --- Home View ---
+function renderHome() {
+  return `
+    ${renderMorningDigest()}
+    ${renderAISummaryHero()}
+    ${renderKpiRow()}
+    ${renderCommitmentsWidget()}
+    ${renderActiveWork()}
+    ${renderNeedsAttention()}
+    ${renderHomeTimeline()}
+  `;
+}
+
+// --- Work View (unchanged kanban) ---
+function renderWork() {
+  const laneSummaryMap = getLaneSummaryMap();
+  const lanes = LANE_ORDER.map((lane) => ({ key: lane, label: LANE_LABELS[lane] || titleCase(lane), count: laneSummaryMap.get(lane) ?? (state?.tasks || []).filter((t) => t.lane === lane).length, tasks: (state?.tasks || []).filter((t) => t.lane === lane) }));
+  return `
+    <nav class="kanban-tabs" aria-label="Work lanes">${lanes.map((l) => `
+      <button class="kanban-tab${l.key === activeKanbanLane ? ' active' : ''}" data-lane="${escapeHtml(l.key)}" type="button">${escapeHtml(l.label)} <span style="opacity:0.6">${l.count}</span></button>`).join('')}
+    </nav>
+    <section class="kanban-board grid">${lanes.map((l) => `
+      <article class="card lane-column kanban-column${l.key === activeKanbanLane ? ' active' : ''}" data-lane="${escapeHtml(l.key)}">
+        <div class="card-header"><h3>${escapeHtml(l.label)}</h3><span class="count-pill">${l.count}</span></div>
+        <div class="task-stack">${l.tasks.length ? l.tasks.map((t) => `
+          <article class="task-card card-interactive"><h4 class="task-title">${escapeHtml(humanize(t.title))}</h4><div class="badge-row">${badge(t.status || 'unknown')}${badge(t.priority || 'default')}${badge(t.project || 'general')}${t.approvalRequired ? badge('waiting_for_human') : ''}</div><div class="list-item-copy">${escapeHtml(t.latestUpdate || 'No update recorded.')}</div><div class="source-ref">${escapeHtml(t.sourceRef || 'work/TASKS.md')}</div></article>`).join('') : '<div class="empty-state empty-state-compact"><div class="empty-copy">No items</div></div>'}</div>
+      </article>`).join('')}
+    </section>`;
+}
+
+// --- Activity View (merged Events + Artifacts + Intel) ---
+function renderActivity() {
+  const events = [...(state?.events || [])].sort((a, b) => new Date(b.timestamp || 0) - new Date(a.timestamp || 0));
+  const artifacts = [...(state?.artifacts || [])].sort((a, b) => new Date(b.createdAt || 0) - new Date(a.createdAt || 0));
+  const memory = state?.memory || {};
+
+  const tabs = [
+    { key: 'all', label: 'All' },
+    { key: 'events', label: 'Events' },
+    { key: 'artifacts', label: 'Artifacts' },
+    { key: 'memory', label: 'Memory' }
+  ];
+
+  let content = '';
+  if (activeActivityTab === 'all' || activeActivityTab === 'events') {
+    content += events.map((e) => `
+      <div class="v5-activity-row">
+        <span class="v5-activity-type-icon" title="Event">⊙</span>
+        <span class="v5-activity-time">${escapeHtml(formatTimelineTime(e.timestamp))}</span>
+        <span class="v5-activity-summary">${escapeHtml(e.summary || 'Untitled event')}</span>
+        <span>${badge(e.verificationState || e.status || 'info')}</span>
+      </div>
     `).join('');
-    return `<div class="nav-group-label">${group}</div>${items}`;
-  }).join('');
-  nav.querySelectorAll('[data-view]').forEach((button) => button.addEventListener('click', () => navigateTo(button.dataset.view)));
+  }
+  if (activeActivityTab === 'all' || activeActivityTab === 'artifacts') {
+    content += artifacts.map((a) => `
+      <div class="v5-activity-row">
+        <span class="v5-activity-type-icon" title="Artifact">◫</span>
+        <span class="v5-activity-time">${escapeHtml(formatTimelineTime(a.createdAt))}</span>
+        <span class="v5-activity-summary">${escapeHtml(a.title || 'Untitled artifact')}</span>
+        <span>${badge(a.category || 'artifact')}</span>
+      </div>
+    `).join('');
+  }
+  if (activeActivityTab === 'all' || activeActivityTab === 'memory') {
+    const memEntries = [
+      ...(memory.keyEvents || []).map((item, i) => ({ text: item, type: 'Key Event', time: '' })),
+      ...(memory.decisions || []).map((item) => ({ text: item, type: 'Decision', time: '' })),
+      ...(memory.facts || []).map((item) => ({ text: item, type: 'Fact', time: '' }))
+    ];
+    content += memEntries.map((m) => `
+      <div class="v5-activity-row">
+        <span class="v5-activity-type-icon" title="Memory">◉</span>
+        <span class="v5-activity-time">${escapeHtml(m.time)}</span>
+        <span class="v5-activity-summary">${escapeHtml(m.text)}</span>
+        <span>${badge(m.type)}</span>
+      </div>
+    `).join('');
+  }
+
+  if (!content) content = '<div class="v5-empty">No activity recorded.</div>';
+
+  return `
+    <nav class="v5-tabs" aria-label="Activity tabs">
+      ${tabs.map((t) => `<button class="v5-tab${t.key === activeActivityTab ? ' active' : ''}" data-activity-tab="${t.key}" type="button">${t.label}</button>`).join('')}
+    </nav>
+    <section class="v5-activity-list">${content}</section>
+  `;
+}
+
+// --- Agents View ---
+function renderDeliveryHistory() {
+  const items = [...(state?.commitments || [])].filter((c) => ['delivered', 'missed'].includes(c.status)).sort((a, b) => new Date(b.madeAt || 0) - new Date(a.madeAt || 0));
+  if (!items.length) return '';
+  return `
+    <div class="delivery-history"><div class="memory-block-title">Delivery History</div>${items.map((c) => `<div class="delivery-history-row"><span class="delivery-history-row__date">${escapeHtml(formatDateTime(c.madeAt))}</span><span class="delivery-history-row__title">${badge(c.status || 'in_progress')}${escapeHtml(c.title || 'Untitled')}</span><span class="delivery-history-row__time">${escapeHtml(getCommitmentTimeContext(c))}</span></div>`).join('')}</div>`;
+}
+
+function renderAgents() {
+  const agents = state?.agents || [];
+  return `
+    <section class="grid agent-grid">${agents.map((agent, i) => `
+      <article class="card agent-card"><div class="agent-header"><div><div class="agent-name">${truthDot(agent)}${escapeHtml(agent.name || 'Unnamed')}</div></div>${badge(agent.status || 'unknown')}</div><p class="agent-role">${escapeHtml(agent.role || 'No role.')}</p><div class="key-value-grid agent-meta"><div class="key-label">Model</div><div class="key-value">${escapeHtml(agent.model || 'unknown')}</div><div class="key-label">Environment</div><div class="key-value">${escapeHtml(agent.environment || agent.provider || 'unknown')}</div><div class="key-label">Current Task</div><div class="key-value">${escapeHtml(agent.currentTaskSummary || '—')}</div><div class="key-label">Health</div><div class="key-value">${badge(agent.health || 'unknown')}</div><div class="key-label">Last Seen</div><div class="key-value">${escapeHtml(formatRelative(agent.lastSeenAt))}</div><div class="key-label">Activity</div><div class="key-value">${escapeHtml(String(agent.recentActivityCount ?? 0))}</div></div>${i === 0 ? renderDeliveryHistory() : ''}</article>`).join('')}
+    </section>`;
+}
+
+// --- Settings View (merged Schedule + Usage/Cost + System) ---
+function renderSettings() {
+  const tabs = [
+    { key: 'spend', label: 'Spend' },
+    { key: 'schedule', label: 'Schedule' },
+    { key: 'system', label: 'System' }
+  ];
+
+  let content = '';
+  if (activeSettingsTab === 'spend') {
+    content = renderSettingsSpend();
+  } else if (activeSettingsTab === 'schedule') {
+    content = renderSettingsSchedule();
+  } else {
+    content = renderSettingsSystem();
+  }
+
+  return `
+    <nav class="v5-tabs" aria-label="Settings tabs">
+      ${tabs.map((t) => `<button class="v5-tab${t.key === activeSettingsTab ? ' active' : ''}" data-settings-tab="${t.key}" type="button">${t.label}</button>`).join('')}
+    </nav>
+    ${content}
+  `;
+}
+
+function renderSettingsSpend() {
+  const usage = state?.usage || [];
+  const total = usage.reduce((s, r) => s + Number(r.estimatedCostUsd || 0), 0);
+  const topDriver = [...usage].sort((a, b) => Number(b.estimatedCostUsd || 0) - Number(a.estimatedCostUsd || 0))[0];
+
+  return `
+    <section class="grid grid-3">
+      ${renderKpiCard('Total Spend Today', money(total), usage.length ? 'From ledger files' : 'No usage rows', 'accent', true)}
+      ${renderKpiCard('Top Cost Driver', topDriver?.agent || '—', topDriver ? `${money(topDriver.estimatedCostUsd)} · ${humanize(topDriver.operationType)}` : 'No data', 'info')}
+      ${renderKpiCard('Records', String(usage.length), 'Structured ledger rows', 'success')}
+    </section>
+    ${usage.length ? `<section class="card"><div class="card-header"><h3>Usage Records</h3></div><div class="table-wrap"><table class="table usage-table"><thead><tr><th>Agent</th><th>Model</th><th>Provider</th><th>Operation</th><th>Cost</th><th>Duration</th><th>Success</th></tr></thead><tbody>${usage.map((r) => `<tr><td data-label="Agent">${important(r.agent || 'Unknown')}</td><td data-label="Model">${important(r.model || 'unknown')}</td><td data-label="Provider">${escapeHtml(r.provider || 'unknown')}</td><td data-label="Operation">${escapeHtml(humanize(r.operationType || 'unknown'))}</td><td data-label="Cost" class="table-mono table-strong">${money(r.estimatedCostUsd || 0)}</td><td data-label="Duration" class="table-mono">${duration(r.durationMs)}</td><td data-label="Success">${badge(r.success ? 'success' : 'failed')}</td></tr>`).join('')}</tbody></table></div></section>` : '<section class="card"><div class="v5-empty">No usage records yet.</div></section>'}
+  `;
+}
+
+function renderSettingsSchedule() {
+  const schedules = state?.schedules || [];
+  return `
+    <section class="card"><div class="card-header"><h3>Schedule</h3></div><div class="table-wrap"><table class="table"><thead><tr><th>Name</th><th>Status</th><th>Owner</th><th>Last Run</th><th>Result</th><th>Next Run</th></tr></thead><tbody>${schedules.map((s) => `<tr><td>${important(s.name || 'Unnamed')}<div class="list-item-copy">${escapeHtml(s.humanReadable || '')}</div></td><td>${badge(s.status || 'unknown')}</td><td>${important(s.ownerAgent || '—')}</td><td class="table-mono">${escapeHtml(formatRelative(s.lastRunAt))}</td><td>${badge(s.lastRunStatus || 'unknown')}</td><td class="table-mono">${escapeHtml(formatDateTime(s.nextRunAt))}</td></tr>`).join('')}</tbody></table></div></section>
+  `;
+}
+
+function renderSettingsSystem() {
+  const dq = state?.overview?.dataQuality || {};
+  const tg = state?.truthGaps || {};
+  const ds = state?.meta?.dataSources || [];
+  return `
+    <section class="card">
+      <div class="card-header"><h3>Data Quality</h3></div>
+      <div class="key-value-grid">
+        <div class="key-label">Verified</div><div class="key-value">${dq.verified || 0}</div>
+        <div class="key-label">Claimed</div><div class="key-value">${dq.claimed || 0}</div>
+        <div class="key-label">Stale</div><div class="key-value">${dq.stale || 0}</div>
+        <div class="key-label">Unknown</div><div class="key-value">${dq.unknown || 0}</div>
+      </div>
+    </section>
+    <section class="card">
+      <div class="card-header"><h3>Truth Gaps</h3></div>
+      <div class="key-value-grid">
+        ${Object.entries(tg).map(([k, v]) => `<div class="key-label">${escapeHtml(humanize(k))}</div><div class="key-value">${escapeHtml(humanize(v))}</div>`).join('')}
+      </div>
+    </section>
+    <section class="card">
+      <div class="card-header"><h3>Data Sources</h3><div class="card-subtitle">${ds.length} sources</div></div>
+      <div class="spec-source-list">${ds.map((s) => `<code>${escapeHtml(s)}</code>`).join('')}</div>
+    </section>
+  `;
 }
 
 function renderKpiCard(label, value, description, tone = 'info', isMoney = false) {
@@ -144,338 +614,314 @@ function renderKpiCard(label, value, description, tone = 'info', isMoney = false
   `;
 }
 
-function getNeedsMeCount() {
-  return getPendingApprovals().length + (state?.tasks || []).filter((task) => task.status === 'waiting_for_human').length;
-}
+const RENDERERS = { home: renderHome, work: renderWork, activity: renderActivity, agents: renderAgents, settings: renderSettings };
 
-function computeDataConfidence(dataQuality = {}) {
-  const total = Object.values(dataQuality).reduce((sum, value) => sum + Number(value || 0), 0);
-  if (!total) return 0;
-  return Math.round(((Number(dataQuality.verified || 0)) / total) * 100);
-}
-
-function getStatusBannerState() {
-  const agent = state?.agents?.[0];
-  const approvals = getPendingApprovals().length;
-  const waitingTasks = (state?.tasks || []).filter((task) => task.status === 'waiting_for_human').length;
-  const commitments = state?.commitments || [];
-  const atRisk = commitments.filter((item) => item.status === 'at_risk').length;
-  const missed = commitments.filter((item) => item.status === 'missed').length;
-  const heartbeatAgeMs = agent?.lastHeartbeatAt ? Date.now() - new Date(agent.lastHeartbeatAt).getTime() : Number.POSITIVE_INFINITY;
-  if (!agent?.lastHeartbeatAt || heartbeatAgeMs > 2 * 60 * 60 * 1000) return 'offline';
-  if (missed || getOpenAlerts().some((alert) => String(alert.severity).toLowerCase() === 'critical') || heartbeatAgeMs > 30 * 60 * 1000) return 'stalled';
-  if (approvals || waitingTasks || atRisk || heartbeatAgeMs > 10 * 60 * 1000) return 'attention';
-  return 'ok';
-}
-
-function formatBannerLabel(stateKey) {
-  return ({ ok: 'OPERATING NORMALLY', attention: 'NEEDS ATTENTION', stalled: 'STALLED', offline: 'OFFLINE' })[stateKey] || 'OPERATING NORMALLY';
-}
-
-function renderStatusBanner() {
-  const agent = state?.agents?.[0] || {};
-  const stateKey = getStatusBannerState();
-  const needsMe = getNeedsMeCount();
-  const attentionCopy = needsMe ? `${needsMe} item${needsMe === 1 ? '' : 's'} need${needsMe === 1 ? 's' : ''} your attention` : 'No human input needed';
-  return `
-    <section class="status-banner status-banner--${stateKey}">
-      <div class="status-banner__top">
-        <div class="status-banner__label">${badge(stateKey, formatBannerLabel(stateKey))}</div>
-        <div class="status-banner__age">${escapeHtml(formatRelative(agent.lastHeartbeatAt))}</div>
-      </div>
-      <div class="status-banner__line"><span class="status-banner__key">Currently:</span> ${escapeHtml(agent.currentTaskSummary || 'No live task recorded')}</div>
-      <div class="status-banner__meta">
-        <span><span class="status-banner__key">Since:</span> ${escapeHtml(formatDateTime(agent.lastHeartbeatAt))}</span>
-        <span><span class="status-banner__key">Duration:</span> ${escapeHtml(formatRelative(agent.lastHeartbeatAt).replace('ago', '').trim() || 'just now')}</span>
-      </div>
-      <div class="status-banner__line"><span class="status-banner__key">Next:</span> ${escapeHtml(state?.meta?.nextActions?.[0] || 'No next action recorded')}</div>
-      <div class="status-banner__footer">
-        <span>${escapeHtml(attentionCopy)}</span>
-        <button type="button" class="btn btn-secondary" data-nav-view="approvals">View →</button>
-      </div>
-    </section>
-  `;
-}
-
-function getCommitmentTimeContext(commitment) {
-  const due = commitment?.dueBy ? new Date(commitment.dueBy).getTime() : null;
-  const resolved = commitment?.resolvedAt ? new Date(commitment.resolvedAt).getTime() : null;
-  if (!due) return 'No deadline';
-  const deltaMs = (resolved || Date.now()) - due;
-  const absMin = Math.round(Math.abs(deltaMs) / 60000);
-  const hrs = Math.floor(absMin / 60);
-  const mins = absMin % 60;
-  const span = hrs ? `${hrs}h ${mins}m` : `${mins}min`;
-  if (commitment.status === 'delivered') return deltaMs <= 0 ? `✓ ${span} ahead of schedule` : `✓ ${span} late (still delivered)`;
-  if (commitment.status === 'missed') return `✗ overdue by ${span}`;
-  if (commitment.status === 'at_risk' || commitment.status === 'in_progress') return `⏱ ${span} remaining`;
-  return commitment.proof ? `✓ ${commitment.proof}` : 'Cancelled';
-}
-
-function renderCommitments() {
-  const commitments = [...(state?.commitments || [])].sort((a, b) => new Date(b.madeAt || 0) - new Date(a.madeAt || 0));
-  if (!commitments.length) return '';
-  const stats = state?.overview?.commitmentStats || {};
-  return `
-    <section class="card">
-      <div class="card-header">
-        <h3>Commitments</h3>
-        <div class="card-subtitle">${stats.commitmentsMade || commitments.length} made · ${stats.delivered || 0} delivered · ${stats.missed || 0} missed</div>
-      </div>
-      <div class="commitment-list">
-        ${commitments.map((item) => `
-          <div class="commitment-row commitment-row--${escapeHtml(item.status || 'in_progress')}" data-commitment-due-by="${escapeHtml(item.dueBy || '')}" data-commitment-status="${escapeHtml(item.status || 'in_progress')}" data-commitment-resolved-at="${escapeHtml(item.resolvedAt || '')}">
-            <div class="commitment-row__main">
-              <div class="commitment-row__title">${badge(item.status || 'in_progress')}${escapeHtml(item.title || 'Untitled commitment')}</div>
-              <div class="commitment-row__context">${escapeHtml(item.context || 'No context recorded')}</div>
-            </div>
-            <div class="commitment-countdown">${escapeHtml(getCommitmentTimeContext(item))}</div>
-          </div>
-        `).join('')}
-      </div>
-    </section>
-  `;
-}
-
-function renderDeliveryScorecard() {
-  const stats = state?.overview?.commitmentStats || {};
-  const deliveryRate = stats.commitmentsMade ? Math.round(((stats.delivered || 0) / stats.commitmentsMade) * 100) : 0;
-  const onTimeRate = stats.delivered ? `${stats.onTime || 0}/${stats.delivered}` : '0/0';
-  const tone = deliveryRate > 80 ? 'success' : deliveryRate >= 50 ? 'warning' : 'error';
-  return `
-    <section class="card">
-      <div class="card-header">
-        <h3>Delivery Track Record</h3>
-        <div class="card-subtitle">Last 7 days</div>
-      </div>
-      <div class="scorecard-row scorecard-row--${tone}">Delivered: <strong>${stats.delivered || 0}/${stats.commitmentsMade || 0} (${deliveryRate}%)</strong> <span>|</span> On time: <strong>${onTimeRate}</strong> <span>|</span> Avg delivery: <strong>${escapeHtml(stats.avgDeliveryLead || '—')}</strong></div>
-    </section>
-  `;
-}
-
-function renderKpiStrip() {
-  const overview = state?.overview || {};
-  const confidence = computeDataConfidence(overview.dataQuality || {});
-  const needsMe = getNeedsMeCount();
-  return `
-    <section class="grid kpi-grid">
-      ${renderKpiCard('Tasks Active', String(overview.tasksInProgress ?? 0), 'Things being actively pushed right now.', 'info')}
-      ${renderKpiCard('Needs Me', String(needsMe), 'Approvals or waiting-for-human blockers.', needsMe >= 3 ? 'error' : needsMe >= 1 ? 'warning' : 'success')}
-      ${renderKpiCard('Spend Today', money(overview.spendTodayUsd ?? 0), 'Usage-backed cost for the day.', 'accent', true)}
-      ${renderKpiCard('Data Confidence', `${confidence}% verified`, 'Verified entities across the current state.', confidence > 80 ? 'success' : confidence >= 50 ? 'warning' : 'error')}
-    </section>
-  `;
-}
-
-function renderCurrentWork() {
-  const tasks = (state?.tasks || []).filter((task) => task.lane === 'now');
-  return `
-    <section class="card">
-      <div class="card-header">
-        <h3>Current Work</h3>
-        <div class="card-subtitle">${tasks.length} active</div>
-      </div>
-      <div class="current-work-list">
-        ${tasks.length ? tasks.map((task) => `
-          <div class="current-work-item">
-            <span class="current-work-item__dot"></span>
-            <span class="current-work-item__title">${escapeHtml(task.title || 'Untitled task')}</span>
-            <span>${badge(task.status || 'in_progress')}</span>
-            <span>${badge(task.project || 'general')}</span>
-          </div>
-        `).join('') : '<div class="empty-copy">No active now-lane tasks.</div>'}
-      </div>
-      <div class="section-footer"><button type="button" class="link-button" data-nav-view="work">View all →</button></div>
-    </section>
-  `;
-}
-
-function renderCompactProblems() {
-  const problems = getOpenAlerts();
-  return `
-    <article class="card">
-      <div class="card-header">
-        <h3>Problems</h3>
-        <div class="card-subtitle">${problems.length} open</div>
-      </div>
-      <div class="problem-list">
-        ${problems.length ? problems.map((problem, index) => `
-          <div class="problem-card problem-item${index === 0 ? '' : ''}">
-            <button class="problem-toggle" type="button">
-              <span class="problem-toggle__title">${badge(problem.severity || problem.status || 'info')}${escapeHtml(problem.title || 'Untitled problem')}</span>
-            </button>
-            <div class="problem-description">${escapeHtml(problem.description || 'No details available.')}</div>
-            <div class="problem-next">→ Next: ${escapeHtml(problem.recommendedAction || 'Review the state and respond.')}</div>
-          </div>
-        `).join('') : '<div class="empty-copy">No open problems.</div>'}
-      </div>
-    </article>
-  `;
-}
-
-function renderCompactApprovals() {
-  const approvals = getPendingApprovals();
-  if (!approvals.length) return '';
-  return `
-    <article class="card">
-      <div class="card-header">
-        <h3>Needs Your Decision</h3>
-        <div class="card-subtitle">${approvals.length} pending</div>
-      </div>
-      <div class="compact-approval-list">
-        ${approvals.map((approval) => `
-          <div class="compact-approval-item" data-approval-id="${escapeHtml(approval.id)}">
-            <div class="compact-approval-item__title">${escapeHtml(approval.title || approval.id)}</div>
-            <div class="compact-approval-item__meta">Requested by: ${escapeHtml(approval.requestedBy || 'Mission Control')} · ${escapeHtml(humanize(approval.urgency || 'medium'))} urgency</div>
-            <div class="action-row">
-              <button class="btn btn-success" type="button" data-approval-action="approved" data-approval-id="${escapeHtml(approval.id)}">Approve</button>
-              <button class="btn btn-destructive" type="button" data-approval-action="rejected" data-approval-id="${escapeHtml(approval.id)}">Reject</button>
-            </div>
-            <div class="confirmation-slot"></div>
-          </div>
-        `).join('')}
-      </div>
-    </article>
-  `;
-}
-
-function renderCompactActivity() {
-  const events = [...(state?.events || [])].sort((a, b) => new Date(b.timestamp || 0) - new Date(a.timestamp || 0)).slice(0, 5);
-  return `
-    <section class="card">
-      <div class="card-header">
-        <h3>Recent Activity</h3>
-        <div class="card-subtitle">Last 5 events</div>
-      </div>
-      <div class="activity-list">
-        ${events.map((event) => `
-          <div class="activity-row">
-            <span class="activity-row__time">${escapeHtml(formatDateTime(event.timestamp))}</span>
-            <span class="activity-row__summary">${escapeHtml(event.summary || 'Untitled event')}</span>
-            <span>${badge(event.verificationState || event.status || 'info')}</span>
-          </div>
-        `).join('')}
-      </div>
-      <div class="section-footer"><button type="button" class="link-button" data-nav-view="events">View all →</button></div>
-    </section>
-  `;
-}
-
-function renderOverview() {
-  return `
-    ${renderStatusBanner()}
-    ${renderCommitments()}
-    ${renderDeliveryScorecard()}
-    ${renderKpiStrip()}
-    ${renderCurrentWork()}
-    <section class="grid split-grid">
-      ${renderCompactProblems()}
-      ${renderCompactApprovals()}
-    </section>
-    ${renderCompactActivity()}
-  `;
-}
-
-function renderWork() {
-  const laneSummaryMap = getLaneSummaryMap();
-  const lanes = LANE_ORDER.map((lane) => ({ key: lane, label: LANE_LABELS[lane] || titleCase(lane), count: laneSummaryMap.get(lane) ?? (state?.tasks || []).filter((task) => task.lane === lane).length, tasks: (state?.tasks || []).filter((task) => task.lane === lane) }));
-  return `
-    <nav class="kanban-tabs" aria-label="Work lanes">${lanes.map((lane) => `
-      <button class="kanban-tab${lane.key === activeKanbanLane ? ' active' : ''}" data-lane="${escapeHtml(lane.key)}" type="button">${escapeHtml(lane.label)} <span style="opacity:0.6">${lane.count}</span></button>`).join('')}
-    </nav>
-    <section class="kanban-board grid">${lanes.map((lane) => `
-      <article class="card lane-column kanban-column${lane.key === activeKanbanLane ? ' active' : ''}" data-lane="${escapeHtml(lane.key)}">
-        <div class="card-header"><h3>${escapeHtml(lane.label)}</h3><span class="count-pill">${lane.count}</span></div>
-        <div class="task-stack">${lane.tasks.length ? lane.tasks.map((task) => `
-          <article class="task-card card-interactive"><h4 class="task-title">${escapeHtml(humanize(task.title))}</h4><div class="badge-row">${badge(task.status || 'unknown')}${badge(task.priority || 'default')}${badge(task.project || 'general')}${task.approvalRequired ? badge('waiting_for_human') : ''}</div><div class="list-item-copy">${escapeHtml(task.latestUpdate || 'No update recorded.')}</div><div class="source-ref">${escapeHtml(task.sourceRef || 'work/TASKS.md')}</div></article>`).join('') : '<div class="empty-state empty-state-compact"><div class="empty-copy">No items</div></div>'}</div>
-      </article>`).join('')}
-    </section>`;
-}
-
-function renderApprovals() {
-  const approvals = state?.approvals || [];
-  if (!approvals.length) return '<section class="card"><div class="empty-state"><div><div class="task-title">No approvals waiting</div><div class="empty-copy">Approval cards will appear here when the ledger has pending decisions.</div></div></div></section>';
-  return `
-    <section class="grid approvals-grid">${approvals.map((approval) => `
-      <article class="card approval-card" data-approval-id="${escapeHtml(approval.id)}"><div class="approval-header"><h3 class="approval-title">${escapeHtml(approval.title || approval.id)}</h3>${badge(approval.status || 'pending')}</div><div class="key-value-grid approval-meta"><div class="key-label">Urgency</div><div class="key-value">${badge(approval.urgency || 'medium')}</div><div class="key-label">Risk</div><div class="key-value">${escapeHtml(humanize(approval.riskCategory || 'other'))}</div><div class="key-label">Requested by</div><div class="key-value">${escapeHtml(approval.requestedBy || 'Mission Control')}</div><div class="key-label">Requested at</div><div class="key-value table-mono">${escapeHtml(formatDateTime(approval.requestedAt))}</div></div><p class="approval-reason">${escapeHtml(approval.reason || 'No reason recorded.')}</p><div class="approval-consequence">${escapeHtml(approval.consequence || 'Decision consequence not recorded.')}</div>${String(approval.status).toLowerCase() === 'pending' ? `<div class="action-row" style="margin-top:12px;"><button class="btn btn-success" type="button" data-approval-action="approved" data-approval-id="${escapeHtml(approval.id)}">Approve</button><button class="btn btn-destructive" type="button" data-approval-action="rejected" data-approval-id="${escapeHtml(approval.id)}">Reject</button></div><div class="confirmation-slot"></div>` : '<div class="confirmation-inline">Resolution recorded.</div>'}</article>`).join('')}
-    </section>`;
-}
-
-function renderEvents() {
-  const events = [...(state?.events || [])].sort((a, b) => new Date(b.timestamp || 0) - new Date(a.timestamp || 0));
-  return `
-    <section class="card events-card"><div class="card-header"><h3>Event Ledger</h3><div class="card-subtitle">Reverse chronological</div></div><div class="events-list">${events.map((event) => `
-      <div class="events-list-item"><div class="event-time">${escapeHtml(formatDateTime(event.timestamp))}</div><div class="list-item-copy">${escapeHtml(event.actor || 'Unknown actor')}</div><div class="list-item-copy">${escapeHtml(humanize(event.type || 'event'))}</div><div class="event-summary">${escapeHtml(event.summary || 'No summary')}</div><div>${badge(event.status || 'info')}</div><div>${truthBadge(event)}</div></div>`).join('')}</div></section>`;
-}
-
-function renderDeliveryHistory() {
-  const items = [...(state?.commitments || [])].filter((item) => ['delivered', 'missed'].includes(item.status)).sort((a, b) => new Date(b.madeAt || 0) - new Date(a.madeAt || 0));
-  if (!items.length) return '';
-  return `
-    <div class="delivery-history"><div class="memory-block-title">Delivery History</div>${items.map((item) => `<div class="delivery-history-row"><span class="delivery-history-row__date">${escapeHtml(formatDateTime(item.madeAt))}</span><span class="delivery-history-row__title">${badge(item.status || 'in_progress')}${escapeHtml(item.title || 'Untitled commitment')}</span><span class="delivery-history-row__time">${escapeHtml(getCommitmentTimeContext(item))}</span></div>`).join('')}</div>`;
-}
-
-function renderAgents() {
-  const agents = state?.agents || [];
-  return `
-    <section class="grid agent-grid">${agents.map((agent, index) => `
-      <article class="card agent-card"><div class="agent-header"><div><div class="agent-name">${truthDot(agent)}${escapeHtml(agent.name || 'Unnamed agent')}</div></div>${badge(agent.status || 'unknown')}</div><p class="agent-role">${escapeHtml(agent.role || 'No role recorded.')}</p><div class="key-value-grid agent-meta"><div class="key-label">Model</div><div class="key-value">${escapeHtml(agent.model || 'unknown')}</div><div class="key-label">Environment</div><div class="key-value">${escapeHtml(agent.environment || agent.provider || 'unknown')}</div><div class="key-label">Current Task</div><div class="key-value">${escapeHtml(agent.currentTaskSummary || '—')}</div><div class="key-label">Health</div><div class="key-value">${badge(agent.health || 'unknown')}</div><div class="key-label">Last Seen</div><div class="key-value">${escapeHtml(formatRelative(agent.lastSeenAt))}</div><div class="key-label">Activity</div><div class="key-value">${escapeHtml(String(agent.recentActivityCount ?? 0))}</div></div>${index === 0 ? renderDeliveryHistory() : ''}</article>`).join('')}
-    </section>`;
-}
-
-function renderSchedule() { const schedules = state?.schedules || []; return `
-<section class="card"><div class="card-header"><h3>Schedule</h3><div class="card-subtitle">Run ledger</div></div><div class="table-wrap"><table class="table"><thead><tr><th>Name / Description</th><th>Status</th><th>Owner</th><th>Last Run</th><th>Last Result</th><th>Next Run</th></tr></thead><tbody>${schedules.map((schedule) => `<tr><td>${important(schedule.name || 'Unnamed schedule')}<div class="list-item-copy">${escapeHtml(schedule.humanReadable || schedule.description || 'No description')}</div></td><td>${badge(schedule.status || 'unknown')}</td><td>${important(schedule.ownerAgent || '—')}</td><td class="table-mono">${escapeHtml(formatRelative(schedule.lastRunAt))}</td><td>${badge(schedule.lastRunStatus || 'unknown')}</td><td class="table-mono">${escapeHtml(formatDateTime(schedule.nextRunAt))}</td></tr>`).join('')}</tbody></table></div></section>`; }
-function renderUsageCost() { const usage = state?.usage || []; const total = usage.reduce((sum, row) => sum + Number(row.estimatedCostUsd || 0), 0); const topDriver = [...usage].sort((a, b) => Number(b.estimatedCostUsd || 0) - Number(a.estimatedCostUsd || 0))[0]; const truthLevel = state?.truthGaps?.usageCost || (usage.length ? 'verified' : 'unknown'); return `
-<section class="grid grid-3">${renderKpiCard('Total Spend Today', money(total), usage.length ? 'Usage rows loaded from ledger files.' : 'No usage rows found yet.', 'accent', true)}${renderKpiCard('Top Cost Driver', topDriver?.agent || '—', topDriver ? `${money(topDriver.estimatedCostUsd)} · ${humanize(topDriver.operationType)}` : 'Waiting for ledger data.', 'info')}${renderKpiCard('Truth Level', titleCase(truthLevel), 'Confidence state for usage and cost data.', 'success')}</section>${usage.length ? `<section class="card"><div class="card-header"><h3>Usage Records</h3><div class="card-subtitle">Structured ledger rows</div></div><div class="table-wrap"><table class="table usage-table"><thead><tr><th>Agent</th><th>Model</th><th>Provider</th><th>Operation</th><th>Cost</th><th>Duration</th><th>Success</th><th>Source</th></tr></thead><tbody>${usage.map((row) => `<tr><td data-label="Agent">${important(row.agent || 'Unknown')}</td><td data-label="Model">${important(row.model || 'unknown')}</td><td data-label="Provider">${escapeHtml(row.provider || 'unknown')}</td><td data-label="Operation">${escapeHtml(humanize(row.operationType || 'unknown'))}</td><td data-label="Cost" class="table-mono table-strong">${escapeHtml(money(row.estimatedCostUsd || 0))}</td><td data-label="Duration" class="table-mono">${escapeHtml(duration(row.durationMs))}</td><td data-label="Success">${badge(row.success ? 'success' : 'failed')}</td><td data-label="Source" class="table-mono">${escapeHtml(row.sourcePath || row._truth?.source || '—')}</td></tr>`).join('')}</tbody></table></div></section>` : `<section class="card"><div class="empty-state"><div><div class="task-title">No usage records yet</div><div class="empty-copy">Add structured usage ledger files and this view will light up with spend, duration, and source rows.</div></div></div></section>`}`; }
-function renderArtifacts() { const artifacts = state?.artifacts || []; return `<section class="grid artifacts-grid">${artifacts.map((artifact) => `<article class="card artifact-card"><div class="artifact-header"><div class="artifact-title">${escapeHtml(artifact.title || 'Untitled artifact')}</div>${badge(artifact.category || 'artifact')}</div><div class="key-value-grid artifact-meta"><div class="key-label">Format</div><div class="key-value">${escapeHtml(artifact.format || '—')}</div><div class="key-label">Project</div><div class="key-value">${escapeHtml(artifact.project || '—')}</div><div class="key-label">Creator</div><div class="key-value">${escapeHtml(artifact.creator || '—')}</div><div class="key-label">Created</div><div class="key-value table-mono">${escapeHtml(formatDateTime(artifact.createdAt))}</div><div class="key-label">Path</div><div class="key-value path-mono">${escapeHtml(artifact.path || '—')}</div></div></article>`).join('')}</section>`; }
-function renderIntel() { const memory = state?.memory || {}; return `<section class="grid memory-grid"><article class="card"><div class="card-header"><h3>Memory Intelligence</h3><div class="card-subtitle">Key events, decisions, facts</div></div><div class="memory-block"><div class="memory-block-title">Key Events</div><ul class="memory-list">${(memory.keyEvents || []).map((item) => `<li>${escapeHtml(item)}</li>`).join('') || '<li>No key events found.</li>'}</ul></div><div class="memory-block"><div class="memory-block-title">Decisions</div><ul class="memory-list">${(memory.decisions || []).map((item) => `<li>${escapeHtml(item)}</li>`).join('') || '<li>No decisions found.</li>'}</ul></div><div class="memory-block"><div class="memory-block-title">Facts</div><ul class="memory-list">${(memory.facts || []).map((item) => `<li>${escapeHtml(item)}</li>`).join('') || '<li>No facts found.</li>'}</ul></div></article><article class="card"><div class="card-header"><h3>Spec & Sources</h3><div class="card-subtitle">Grounding inputs</div></div><div class="memory-block"><div class="memory-block-title">Spec</div><div class="list-item-copy">${escapeHtml(state?.spec?.title || 'Mission Control spec')}</div><div class="list-item-copy">${escapeHtml(state?.spec?.status || 'Status unavailable')}</div></div><div class="memory-block"><div class="memory-block-title">Focus</div><div class="spec-source-list">${(state?.spec?.focus || []).map((item) => `<code>${escapeHtml(item)}</code>`).join('') || '<code>No focus items</code>'}</div></div><div class="memory-block"><div class="memory-block-title">Sources</div><div class="spec-source-list">${(state?.meta?.dataSources || []).map((source) => `<code>${escapeHtml(source)}</code>`).join('') || '<code>No sources found</code>'}</div></div></article></section>`; }
-
-const RENDERERS = { overview: renderOverview, work: renderWork, approvals: renderApprovals, events: renderEvents, agents: renderAgents, schedule: renderSchedule, 'usage-cost': renderUsageCost, artifacts: renderArtifacts, intel: renderIntel };
-
+// --- Interactions ---
 function updateCommitmentCountdowns() {
   document.querySelectorAll('[data-commitment-due-by]').forEach((row) => {
     const dueBy = row.getAttribute('data-commitment-due-by');
     const status = row.getAttribute('data-commitment-status');
     const resolvedAt = row.getAttribute('data-commitment-resolved-at');
-    const target = row.querySelector('.commitment-countdown');
+    const target = row.querySelector('.v5-commitment-time');
     if (!target || !dueBy) return;
     target.textContent = getCommitmentTimeContext({ dueBy, status, resolvedAt });
   });
 }
 
-function bindNavButtons() { app.querySelectorAll('[data-nav-view]').forEach((button) => button.addEventListener('click', () => navigateTo(button.dataset.navView))); }
+function bindNavButtons() {
+  app.querySelectorAll('[data-nav-view]').forEach((btn) => btn.addEventListener('click', () => navigateTo(btn.dataset.navView)));
+}
+
+function bindApprovalActions() {
+  app.querySelectorAll('[data-approval-action]').forEach((btn) => btn.addEventListener('click', async () => {
+    const id = btn.dataset.approvalId;
+    const resolution = btn.dataset.approvalAction;
+    const card = btn.closest('[data-approval-id]');
+    const slot = card?.querySelector('.confirmation-slot');
+    const notesInput = card?.querySelector('.v5-notes-input');
+    const notes = notesInput?.value || '';
+    btn.style.transform = 'scale(0.95)';
+    btn.style.opacity = '0.7';
+    await resolveApproval(id, resolution, notes, slot, btn);
+  }));
+}
+
+function bindNudgeButtons() {
+  app.querySelectorAll('[data-nudge-type]').forEach((btn) => {
+    if (btn._nudgeBound) return;
+    btn._nudgeBound = true;
+    btn.addEventListener('click', async () => {
+      const type = btn.dataset.nudgeType;
+      const targetId = btn.dataset.nudgeTarget || null;
+      const message = btn.dataset.nudgeMessage || '';
+      btn.style.transform = 'scale(0.95)';
+      btn.style.opacity = '0.7';
+      btn.disabled = true;
+      try {
+        const resp = await fetch('/api/nudge', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ type, targetId, message }) });
+        if (!resp.ok) throw new Error(`${resp.status}`);
+        btn.textContent = 'Sent ✓';
+        btn.classList.add('btn-nudge-sent');
+        setTimeout(() => { btn.disabled = false; }, 300000); // 5 min cooldown
+      } catch {
+        btn.style.transform = '';
+        btn.style.opacity = '';
+        btn.disabled = false;
+        btn.classList.add('shake');
+        setTimeout(() => btn.classList.remove('shake'), 300);
+      }
+    });
+  });
+}
+
+function bindSnoozeButtons() {
+  app.querySelectorAll('[data-snooze-id]').forEach((btn) => {
+    if (btn._snoozeBound) return;
+    btn._snoozeBound = true;
+    btn.addEventListener('click', () => {
+      const id = btn.dataset.snoozeId;
+      snoozedProblems[id] = Date.now() + 24 * 60 * 60 * 1000;
+      saveSnoozed();
+      const item = btn.closest('.v5-attention-item');
+      if (item) { item.style.opacity = '0'; setTimeout(() => { item.remove(); }, 200); }
+    });
+  });
+}
+
+function bindCommitmentExpand() {
+  app.querySelectorAll('.v5-commitment-row__main').forEach((main) => {
+    main.addEventListener('click', () => {
+      const detail = main.parentElement.querySelector('.v5-commitment-detail');
+      if (detail) { detail.hidden = !detail.hidden; }
+    });
+  });
+}
+
+function bindProblemExpand() {
+  app.querySelectorAll('.v5-attention-item--problem .v5-attention-item__header').forEach((header) => {
+    header.addEventListener('click', () => {
+      const detail = header.parentElement.querySelector('.v5-attention-detail');
+      if (detail) detail.hidden = !detail.hidden;
+    });
+  });
+}
+
+function bindNotesToggle() {
+  app.querySelectorAll('.v5-notes-toggle').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const form = btn.parentElement.parentElement.querySelector('.v5-notes-form');
+      if (form) form.hidden = !form.hidden;
+    });
+  });
+}
+
+function bindDismissDigest() {
+  const btn = document.getElementById('dismiss-digest');
+  if (btn) {
+    btn.addEventListener('click', () => {
+      localStorage.setItem('mc_last_visit', String(Date.now()));
+      const digest = document.getElementById('morning-digest');
+      if (digest) { digest.style.opacity = '0'; setTimeout(() => digest.remove(), 200); }
+    });
+  }
+}
+
+function bindActivityTabs() {
+  app.querySelectorAll('[data-activity-tab]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      activeActivityTab = btn.dataset.activityTab;
+      draw();
+    });
+  });
+}
+
+function bindSettingsTabs() {
+  app.querySelectorAll('[data-settings-tab]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      activeSettingsTab = btn.dataset.settingsTab;
+      draw();
+    });
+  });
+}
 
 function draw() {
-  if (!RENDERERS[currentView]) currentView = 'overview';
+  if (!RENDERERS[currentView]) currentView = 'home';
   viewTitle.textContent = getViewLabel(currentView);
   renderNav();
   app.classList.remove('fade-in'); void app.offsetWidth; app.classList.add('fade-in');
   app.innerHTML = RENDERERS[currentView]();
-  bindNavButtons(); bindApprovalActions();
+  bindNavButtons();
+  bindApprovalActions();
+  bindNudgeButtons();
+  bindSnoozeButtons();
+  bindCommitmentExpand();
+  bindProblemExpand();
+  bindNotesToggle();
+  bindDismissDigest();
   if (currentView === 'work') initKanbanTabs();
-  if (currentView === 'overview') { initProblemsAccordion(); updateCommitmentCountdowns(); clearInterval(commitmentCountdownInterval); commitmentCountdownInterval = setInterval(updateCommitmentCountdowns, 30000); } else { clearInterval(commitmentCountdownInterval); commitmentCountdownInterval = null; }
+  if (currentView === 'activity') bindActivityTabs();
+  if (currentView === 'settings') bindSettingsTabs();
+  if (currentView === 'home') {
+    updateCommitmentCountdowns();
+    clearInterval(commitmentCountdownInterval);
+    commitmentCountdownInterval = setInterval(updateCommitmentCountdowns, 30000);
+  } else {
+    clearInterval(commitmentCountdownInterval);
+    commitmentCountdownInterval = null;
+  }
 }
 
-function bindApprovalActions() { app.querySelectorAll('[data-approval-action]').forEach((button) => button.addEventListener('click', async () => { const id = button.dataset.approvalId; const resolution = button.dataset.approvalAction; const card = button.closest('[data-approval-id]'); const slot = card?.querySelector('.confirmation-slot'); await resolveApproval(id, resolution, slot); })); }
+function getFreshnessClass(value) {
+  const ageMin = value ? (Date.now() - new Date(value).getTime()) / 60000 : Number.POSITIVE_INFINITY;
+  if (ageMin < 5) return 'fresh';
+  if (ageMin <= 30) return 'aging';
+  return 'stale';
+}
 
-function getFreshnessClass(value) { const ageMin = value ? (Date.now() - new Date(value).getTime()) / 60000 : Number.POSITIVE_INFINITY; if (ageMin < 5) return 'fresh'; if (ageMin <= 30) return 'aging'; return 'stale'; }
 async function loadState() {
-  const cacheBust = Date.now(); let response;
+  const cacheBust = Date.now();
+  let response;
   try { response = await fetch(`/api/state?ts=${cacheBust}`); } catch { response = null; }
-  if (response?.ok) state = await response.json(); else { const fallback = await fetch(`./data/state.json?ts=${cacheBust}`); state = await fallback.json(); }
+  if (response?.ok) state = await response.json();
+  else { const fallback = await fetch(`./data/state.json?ts=${cacheBust}`); state = await fallback.json(); }
   sourceCount.textContent = `${state?.meta?.dataSources?.length || 0} sources`;
   const freshnessClass = getFreshnessClass(state?.meta?.generatedAt);
   generatedAtEl.innerHTML = `<span class="freshness-dot freshness-${freshnessClass}"></span>Generated ${escapeHtml(formatDateTime(state?.meta?.generatedAt))}`;
   lastRefreshedEl.textContent = `Last refreshed ${formatTime(new Date())}`;
-  openAlertsEl.textContent = `${getOpenAlerts().length} open alerts`;
+  const needsMe = getNeedsMeCount();
+  openAlertsEl.textContent = needsMe > 0 ? `${needsMe} needs me` : '0 alerts';
   draw();
 }
 
-async function resolveApproval(id, resolution, slot) { if (!id) return; if (slot) slot.innerHTML = ''; try { const response = await fetch(`/api/approvals/${encodeURIComponent(id)}/resolve`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ resolution }) }); if (!response.ok) throw new Error(`Request failed with ${response.status}`); if (slot) slot.innerHTML = `<div class="confirmation-inline">${escapeHtml(titleCase(resolution))} recorded. Reloading state…</div>`; await loadState(); } catch (error) { if (slot) slot.innerHTML = `<div class="error-inline">${escapeHtml(error.message || 'Approval write failed.')}</div>`; } }
-function syncHash() { const next = location.hash.replace('#', ''); if (next && RENDERERS[next]) { currentView = next; draw(); } }
-function initMobileDrawer() { const hamburger = document.getElementById('hamburger-btn'); const sidebar = document.getElementById('sidebar'); const overlay = document.getElementById('sidebar-overlay'); if (!hamburger || !sidebar || !overlay) return; function openDrawer() { sidebar.classList.add('open'); overlay.classList.add('visible'); document.body.style.overflow = 'hidden'; } function closeDrawer() { sidebar.classList.remove('open'); overlay.classList.remove('visible'); document.body.style.overflow = ''; } hamburger.addEventListener('click', () => { sidebar.classList.contains('open') ? closeDrawer() : openDrawer(); }); overlay.addEventListener('click', closeDrawer); sidebar.addEventListener('click', (e) => { if (e.target.closest('.nav-item') && window.innerWidth <= 768) closeDrawer(); }); }
-function initProblemsAccordion() { document.querySelectorAll('.problem-card').forEach((card) => { const toggle = card.querySelector('.problem-toggle'); toggle?.addEventListener('click', () => card.classList.toggle('expanded')); }); }
-function initKanbanTabs() { const tabs = document.querySelector('.kanban-tabs'); if (!tabs) return; tabs.querySelectorAll('.kanban-tab').forEach((tab) => tab.addEventListener('click', () => { activeKanbanLane = tab.dataset.lane; syncKanbanTabs(); })); syncKanbanTabs(); }
-function syncKanbanTabs() { document.querySelectorAll('.kanban-tab').forEach((tab) => tab.classList.toggle('active', tab.dataset.lane === activeKanbanLane)); document.querySelectorAll('.kanban-column').forEach((col) => col.classList.toggle('active', col.dataset.lane === activeKanbanLane)); }
-async function init() { refreshButton.addEventListener('click', () => loadState()); window.addEventListener('hashchange', syncHash); initMobileDrawer(); await loadState(); refreshInterval = setInterval(async () => { await loadState(); }, 30000); }
+async function loadAISummary() {
+  const stateKey = state?.meta?.generatedAt || '';
+  if (aiSummary && aiSummaryStateKey === stateKey) return;
+  try {
+    const resp = await fetch(`/api/summary?ts=${Date.now()}`);
+    if (resp.ok) {
+      const data = await resp.json();
+      aiSummary = data.summary;
+      aiSummaryStateKey = stateKey;
+      const el = document.getElementById('ai-summary-text');
+      if (el) el.textContent = aiSummary;
+    }
+  } catch { /* fallback summary stays as skeleton */ }
+}
+
+async function resolveApproval(id, resolution, notes, slot, btn) {
+  if (!id) return;
+  if (slot) slot.innerHTML = '';
+  try {
+    const resp = await fetch(`/api/approvals/${encodeURIComponent(id)}/resolve`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ resolution, notes }) });
+    if (!resp.ok) throw new Error(`${resp.status}`);
+    if (btn) { btn.textContent = '✓ Done'; btn.style.transform = ''; btn.style.opacity = ''; }
+    if (slot) slot.innerHTML = `<div class="confirmation-inline">${escapeHtml(titleCase(resolution))} recorded.</div>`;
+    setTimeout(() => loadState(), 1000);
+  } catch (err) {
+    if (btn) { btn.style.transform = ''; btn.style.opacity = ''; btn.classList.add('shake'); setTimeout(() => btn.classList.remove('shake'), 300); }
+    if (slot) slot.innerHTML = `<div class="error-inline">${escapeHtml(err.message || 'Failed.')}</div>`;
+  }
+}
+
+function syncHash() {
+  const next = location.hash.replace('#', '');
+  if (next && RENDERERS[next]) { currentView = next; draw(); }
+}
+
+function initMobileDrawer() {
+  const hamburger = document.getElementById('hamburger-btn');
+  const sidebar = document.getElementById('sidebar');
+  const overlay = document.getElementById('sidebar-overlay');
+  if (!hamburger || !sidebar || !overlay) return;
+  function openDrawer() { sidebar.classList.add('open'); overlay.classList.add('visible'); document.body.style.overflow = 'hidden'; }
+  function closeDrawer() { sidebar.classList.remove('open'); overlay.classList.remove('visible'); document.body.style.overflow = ''; }
+  hamburger.addEventListener('click', () => { sidebar.classList.contains('open') ? closeDrawer() : openDrawer(); });
+  overlay.addEventListener('click', closeDrawer);
+  sidebar.addEventListener('click', (e) => { if (e.target.closest('.nav-item') && window.innerWidth <= 768) closeDrawer(); });
+}
+
+function initKanbanTabs() {
+  const tabs = document.querySelector('.kanban-tabs');
+  if (!tabs) return;
+  tabs.querySelectorAll('.kanban-tab').forEach((tab) => tab.addEventListener('click', () => { activeKanbanLane = tab.dataset.lane; syncKanbanTabs(); }));
+  syncKanbanTabs();
+}
+function syncKanbanTabs() {
+  document.querySelectorAll('.kanban-tab').forEach((tab) => tab.classList.toggle('active', tab.dataset.lane === activeKanbanLane));
+  document.querySelectorAll('.kanban-column').forEach((col) => col.classList.toggle('active', col.dataset.lane === activeKanbanLane));
+}
+
+// --- Pull to Refresh ---
+function initPullToRefresh() {
+  let startY = 0;
+  let pulling = false;
+  const main = document.querySelector('.main');
+  if (!main) return;
+
+  main.addEventListener('touchstart', (e) => {
+    if (window.scrollY === 0) { startY = e.touches[0].clientY; pulling = true; }
+  }, { passive: true });
+
+  main.addEventListener('touchmove', (e) => {
+    if (!pulling) return;
+    const dy = e.touches[0].clientY - startY;
+    if (dy > 80 && window.scrollY === 0) {
+      pulling = false;
+      const indicator = document.getElementById('pull-refresh-indicator');
+      if (indicator) { indicator.classList.add('visible'); }
+      loadState().then(() => {
+        loadAISummary();
+        if (indicator) indicator.classList.remove('visible');
+      });
+    }
+  }, { passive: true });
+
+  main.addEventListener('touchend', () => { pulling = false; }, { passive: true });
+}
+
+// --- Quick Command Bar ---
+function wireCommandBar(formId, inputId, feedbackId) {
+  const form = document.getElementById(formId);
+  const input = document.getElementById(inputId);
+  const feedback = document.getElementById(feedbackId);
+  if (!form || !input) return;
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const msg = input.value.trim();
+    if (!msg) return;
+    input.disabled = true;
+    try {
+      const resp = await fetch('/api/nudge', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ type: 'instruction', message: msg }) });
+      if (!resp.ok) throw new Error(`${resp.status}`);
+      input.value = '';
+      if (feedback) { feedback.textContent = '✓ Sent to Mansa'; feedback.classList.add('visible'); setTimeout(() => feedback.classList.remove('visible'), 3000); }
+    } catch {
+      if (feedback) { feedback.textContent = 'Failed to send'; feedback.classList.add('visible', 'error'); setTimeout(() => { feedback.classList.remove('visible', 'error'); }, 3000); }
+    }
+    input.disabled = false;
+    input.focus();
+  });
+}
+function initCommandBar() {
+  wireCommandBar('command-bar-form', 'command-bar-input', 'command-bar-feedback');
+  wireCommandBar('command-bar-form-desktop', 'command-bar-input-desktop', 'command-bar-feedback-desktop');
+}
+
+async function init() {
+  refreshButton.addEventListener('click', () => { loadState().then(() => loadAISummary()); });
+  window.addEventListener('hashchange', syncHash);
+  initMobileDrawer();
+  initPullToRefresh();
+  initCommandBar();
+  await loadState();
+  // Load AI summary async - never blocks page render
+  loadAISummary();
+  // Record visit
+  localStorage.setItem('mc_last_visit', String(Date.now()));
+  refreshInterval = setInterval(async () => {
+    await loadState();
+    // Only refetch summary if state changed
+    if (state?.meta?.generatedAt !== aiSummaryStateKey) loadAISummary();
+  }, 30000);
+}
 init();

--- a/app.js
+++ b/app.js
@@ -36,6 +36,7 @@ let aiSummaryStateKey = null;
 let activeActivityTab = 'all';
 let activeSettingsTab = 'spend';
 let snoozedProblems = {};
+let nudgeEnabled = false;
 
 // Load snoozed problems from localStorage
 try { snoozedProblems = JSON.parse(localStorage.getItem('mc_snoozed_problems') || '{}'); } catch { snoozedProblems = {}; }
@@ -237,11 +238,11 @@ function renderCommitmentsWidget() {
               <div class="v5-commitment-context">${escapeHtml(c.context || 'No context recorded')}</div>
               ${c.proof ? `<div class="v5-commitment-proof">Proof: ${escapeHtml(c.proof)}</div>` : ''}
               <div class="v5-commitment-dates">Made: ${escapeHtml(formatDateTime(c.madeAt))} · Due: ${escapeHtml(formatDateTime(c.dueBy))}${c.resolvedAt ? ` · Resolved: ${escapeHtml(formatDateTime(c.resolvedAt))}` : ''}</div>
-              <div class="v5-commitment-actions">
+              ${nudgeEnabled ? `<div class="v5-commitment-actions">
                 ${c.status === 'in_progress' ? `<button class="btn btn-secondary btn-sm" type="button" data-nudge-type="deadline_extension" data-nudge-target="${escapeHtml(c.id || '')}">Extend deadline</button>` : ''}
                 ${c.status === 'at_risk' ? `<button class="btn btn-secondary btn-sm" type="button" data-nudge-type="priority_change" data-nudge-target="${escapeHtml(c.id || '')}">I'll handle it</button>` : ''}
                 ${c.status === 'missed' ? `<button class="btn btn-secondary btn-sm" type="button" data-nudge-type="instruction" data-nudge-target="${escapeHtml(c.id || '')}" data-nudge-message="Acknowledged">Acknowledged</button>` : ''}
-              </div>
+              </div>` : ''}
             </div>
           </div>
         `).join('')}
@@ -271,7 +272,7 @@ function renderActiveWork() {
             <span class="v5-work-title">${escapeHtml(t.title || 'Untitled')}</span>
           </div>
           <div class="v5-work-meta">${escapeHtml(t.project || 'general')} · ${escapeHtml(humanize(t.status || 'in progress'))}</div>
-          <button class="btn btn-secondary btn-sm v5-nudge-inline" type="button" data-nudge-type="status_request" data-nudge-target="${escapeHtml(t.id || '')}" data-nudge-message="What's the status on this?">Ask for update</button>
+          ${nudgeEnabled ? `<button class="btn btn-secondary btn-sm v5-nudge-inline" type="button" data-nudge-type="status_request" data-nudge-target="${escapeHtml(t.id || '')}" data-nudge-message="What's the status on this?">Ask for update</button>` : ''}
         </div>
       `).join('')}</div>` : '<div class="v5-empty">No active tasks</div>'}
       ${totalNow > 5 ? `<div class="v5-more">and ${totalNow - 5} more</div>` : ''}
@@ -336,7 +337,7 @@ function renderNeedsAttention() {
               </div>
               <div class="v5-attention-actions">
                 <button class="btn btn-secondary btn-sm" type="button" data-snooze-id="${escapeHtml(item.id)}">Snooze 24h</button>
-                ${String(item.severity).toLowerCase() === 'critical' ? `<button class="btn btn-secondary btn-sm" type="button" data-nudge-type="priority_change" data-nudge-target="${escapeHtml(item.id)}" data-nudge-message="Prioritize this problem">Prioritize this</button>` : ''}
+                ${nudgeEnabled && String(item.severity).toLowerCase() === 'critical' ? `<button class="btn btn-secondary btn-sm" type="button" data-nudge-type="priority_change" data-nudge-target="${escapeHtml(item.id)}" data-nudge-message="Prioritize this problem">Prioritize this</button>` : ''}
               </div>
             </div>
           `;
@@ -784,12 +785,14 @@ async function loadState() {
   try { response = await fetch(`/api/state?ts=${cacheBust}`); } catch { response = null; }
   if (response?.ok) state = await response.json();
   else { const fallback = await fetch(`./data/state.json?ts=${cacheBust}`); state = await fallback.json(); }
+  nudgeEnabled = !!state?.meta?.nudgeEnabled;
   sourceCount.textContent = `${state?.meta?.dataSources?.length || 0} sources`;
   const freshnessClass = getFreshnessClass(state?.meta?.generatedAt);
   generatedAtEl.innerHTML = `<span class="freshness-dot freshness-${freshnessClass}"></span>Generated ${escapeHtml(formatDateTime(state?.meta?.generatedAt))}`;
   lastRefreshedEl.textContent = `Last refreshed ${formatTime(new Date())}`;
   const needsMe = getNeedsMeCount();
   openAlertsEl.textContent = needsMe > 0 ? `${needsMe} needs me` : '0 alerts';
+  updateCommandBarVisibility();
   draw();
 }
 
@@ -905,6 +908,13 @@ function wireCommandBar(formId, inputId, feedbackId) {
 function initCommandBar() {
   wireCommandBar('command-bar-form', 'command-bar-input', 'command-bar-feedback');
   wireCommandBar('command-bar-form-desktop', 'command-bar-input-desktop', 'command-bar-feedback-desktop');
+}
+
+function updateCommandBarVisibility() {
+  const mobileBar = document.querySelector('.v5-command-bar-mobile');
+  const desktopBar = document.querySelector('.sidebar-command-bar');
+  if (mobileBar) mobileBar.style.display = nudgeEnabled ? '' : 'none';
+  if (desktopBar) desktopBar.style.display = nudgeEnabled ? '' : 'none';
 }
 
 async function init() {

--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="theme-color" content="#0A0A0B" />
     <title>Mission Control</title>
     <link rel="stylesheet" href="./styles.css" />
   </head>
@@ -31,29 +34,49 @@
             <span>Mansa</span>
           </div>
           <button id="refresh-data" class="btn btn-secondary sidebar-refresh" type="button">Refresh</button>
+
+          <!-- Desktop command bar -->
+          <div class="sidebar-command-bar">
+            <form id="command-bar-form-desktop" autocomplete="off">
+              <input class="v5-command-input" type="text" placeholder="Tell Mansa something..." id="command-bar-input-desktop" />
+              <button class="v5-command-send" type="submit">Send</button>
+              <div class="v5-command-feedback" id="command-bar-feedback-desktop"></div>
+            </form>
+          </div>
         </div>
       </aside>
 
       <main class="main">
+        <div class="v5-pull-indicator" id="pull-refresh-indicator">Refreshing...</div>
+
         <header class="header-bar">
           <div class="header-left">
             <button class="hamburger-btn" id="hamburger-btn" type="button" aria-label="Open navigation">
               <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true"><rect x="2" y="4" width="16" height="2" rx="1" fill="currentColor"/><rect x="2" y="9" width="16" height="2" rx="1" fill="currentColor"/><rect x="2" y="14" width="16" height="2" rx="1" fill="currentColor"/></svg>
             </button>
             <div class="header-tagline">OBSERVABLE. STEERABLE. COST-AWARE.</div>
-            <h1 class="header-title" id="view-title">Overview</h1>
+            <h1 class="header-title" id="view-title">Home</h1>
           </div>
 
           <div class="header-right">
             <span class="header-pill" id="generated-at">Generated —</span>
             <span class="header-pill" id="last-refreshed">Last refreshed —</span>
-            <span class="header-pill header-pill-alert" id="open-alerts-pill">0 open alerts</span>
+            <span class="header-pill header-pill-alert" id="open-alerts-pill">0 alerts</span>
           </div>
         </header>
 
         <section class="content-wrap">
           <div id="app" class="view fade-in"></div>
         </section>
+
+        <!-- Mobile command bar (sticky bottom) -->
+        <div class="v5-command-bar v5-command-bar-mobile">
+          <form id="command-bar-form" autocomplete="off" style="display:flex;gap:8px;flex:1;align-items:center;">
+            <input class="v5-command-input" type="text" placeholder="Tell Mansa something..." id="command-bar-input" />
+            <button class="v5-command-send" type="submit">Send</button>
+          </form>
+          <div class="v5-command-feedback" id="command-bar-feedback"></div>
+        </div>
       </main>
     </div>
 

--- a/server.mjs
+++ b/server.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import http from 'node:http';
+import https from 'node:https';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -14,6 +15,13 @@ const PUSH_TOKEN = process.env.MC_PUSH_TOKEN || null;
 const PUSH_TTL_MS = 10 * 60 * 1000;
 let pushedState = null;
 let pushedAt = 0;
+
+// AI summary config
+const AI_KEY = process.env.MC_AI_KEY || null;
+const AI_MODEL = process.env.MC_AI_MODEL || 'gemini-2.5-flash';
+const AI_PROVIDER = process.env.MC_AI_PROVIDER || 'google';
+const SUMMARY_CACHE_TTL_MS = 5 * 60 * 1000;
+let summaryCache = { summary: null, generatedAt: null, stateKey: null, cachedAt: 0 };
 
 const contentTypes = {
   '.html': 'text/html; charset=utf-8',
@@ -95,11 +103,152 @@ async function handleApprovalResolve(req, res, id) {
   sendJson(res, 200, { ok: true });
 }
 
+// --- AI Summary ---
+
+function buildSummaryPrompt(state) {
+  const agent = state?.agents?.[0] || {};
+  const overview = state?.overview || {};
+  const commitmentStats = overview.commitmentStats || {};
+  const commitments = state?.commitments || [];
+  const tasks = state?.tasks || [];
+  const approvals = (state?.approvals || []).filter(a => String(a.status).toLowerCase() === 'pending');
+  const alerts = (state?.alerts || []).filter(a => String(a.status).toLowerCase() === 'open');
+  const heartbeatAgeMs = agent.lastHeartbeatAt ? Date.now() - new Date(agent.lastHeartbeatAt).getTime() : null;
+  const heartbeatAge = heartbeatAgeMs != null ? `${Math.round(heartbeatAgeMs / 60000)} minutes` : 'unknown';
+  const activeCommitments = commitments.filter(c => c.status === 'in_progress').length;
+  const atRiskCommitments = commitments.filter(c => c.status === 'at_risk').length;
+  const needsAhmed = approvals.length + tasks.filter(t => t.status === 'waiting_for_human').length;
+  const onTimePercent = commitmentStats.delivered ? Math.round((commitmentStats.onTime || 0) / commitmentStats.delivered * 100) : 0;
+
+  const context = `Current state:
+- Agent health: ${agent.health || 'unknown'}
+- Current task: ${agent.currentTaskSummary || 'None'}
+- Time since last heartbeat: ${heartbeatAge}
+- Active commitments: ${activeCommitments}
+- At-risk commitments: ${atRiskCommitments}
+- Items needing Ahmed: ${needsAhmed}
+- Today's spend: $${Number(overview.spendTodayUsd || 0).toFixed(2)}
+- Delivery record: ${commitmentStats.delivered || 0}/${commitmentStats.commitmentsMade || 0} delivered, ${onTimePercent}% on time`;
+
+  return `You are summarizing the status of an AI agent called Mansa for its founder Ahmed.
+Keep it to 2-3 sentences. Be direct. Use a warm but professional tone.
+Focus on: what's happening right now, whether anything needs Ahmed's attention, and the delivery track record.
+
+${context}
+
+Generate a brief, friendly status summary.`;
+}
+
+function buildFallbackSummary(state) {
+  const agent = state?.agents?.[0] || {};
+  const overview = state?.overview || {};
+  const commitmentStats = overview.commitmentStats || {};
+  const approvals = (state?.approvals || []).filter(a => String(a.status).toLowerCase() === 'pending');
+  const tasks = state?.tasks || [];
+  const needsMe = approvals.length + tasks.filter(t => t.status === 'waiting_for_human').length;
+  const deliveryRate = commitmentStats.commitmentsMade ? Math.round((commitmentStats.delivered || 0) / commitmentStats.commitmentsMade * 100) : 0;
+  const currentTask = agent.currentTaskSummary || 'reviewing workspace state';
+  const needsLine = needsMe > 0 ? `${needsMe} item${needsMe === 1 ? '' : 's'} need${needsMe === 1 ? 's' : ''} your attention.` : 'Nothing needs your attention right now.';
+  return `Mansa is currently working on ${currentTask}. ${needsLine} Delivery rate: ${deliveryRate}%.`;
+}
+
+function httpsRequest(url, options, body) {
+  return new Promise((resolve, reject) => {
+    const req = https.request(url, options, (res) => {
+      const chunks = [];
+      res.on('data', (chunk) => chunks.push(chunk));
+      res.on('end', () => {
+        const raw = Buffer.concat(chunks).toString('utf8');
+        try { resolve({ status: res.statusCode, data: JSON.parse(raw) }); }
+        catch { reject(new Error(`AI API returned non-JSON: ${raw.slice(0, 200)}`)); }
+      });
+    });
+    req.on('error', reject);
+    req.setTimeout(10000, () => { req.destroy(); reject(new Error('AI API timeout')); });
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+async function callAI(prompt) {
+  if (!AI_KEY) throw new Error('MC_AI_KEY not configured');
+
+  if (AI_PROVIDER === 'google') {
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${AI_MODEL}:generateContent?key=${AI_KEY}`;
+    const payload = JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] });
+    const parsed = new URL(url);
+    const resp = await httpsRequest(parsed, { method: 'POST', headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) } }, payload);
+    if (resp.status !== 200) throw new Error(`Google AI API error: ${resp.status}`);
+    return resp.data?.candidates?.[0]?.content?.parts?.[0]?.text || '';
+  }
+
+  if (AI_PROVIDER === 'anthropic') {
+    const payload = JSON.stringify({ model: AI_MODEL, max_tokens: 256, messages: [{ role: 'user', content: prompt }] });
+    const resp = await httpsRequest('https://api.anthropic.com/v1/messages', { method: 'POST', headers: { 'Content-Type': 'application/json', 'x-api-key': AI_KEY, 'anthropic-version': '2023-06-01', 'Content-Length': Buffer.byteLength(payload) } }, payload);
+    if (resp.status !== 200) throw new Error(`Anthropic API error: ${resp.status}`);
+    return resp.data?.content?.[0]?.text || '';
+  }
+
+  if (AI_PROVIDER === 'openai') {
+    const payload = JSON.stringify({ model: AI_MODEL, messages: [{ role: 'user', content: prompt }], max_tokens: 256 });
+    const resp = await httpsRequest('https://api.openai.com/v1/chat/completions', { method: 'POST', headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${AI_KEY}`, 'Content-Length': Buffer.byteLength(payload) } }, payload);
+    if (resp.status !== 200) throw new Error(`OpenAI API error: ${resp.status}`);
+    return resp.data?.choices?.[0]?.message?.content || '';
+  }
+
+  throw new Error(`Unknown AI provider: ${AI_PROVIDER}`);
+}
+
+async function handleSummary(req, res) {
+  const state = getState();
+  const stateKey = state?.meta?.generatedAt || '';
+
+  // Check cache
+  if (summaryCache.summary && summaryCache.stateKey === stateKey && Date.now() - summaryCache.cachedAt < SUMMARY_CACHE_TTL_MS) {
+    return sendJson(res, 200, { summary: summaryCache.summary, generatedAt: summaryCache.generatedAt, model: AI_MODEL, cached: true });
+  }
+
+  const generatedAt = new Date().toISOString();
+  let summary;
+  try {
+    const prompt = buildSummaryPrompt(state);
+    summary = await callAI(prompt);
+  } catch {
+    summary = buildFallbackSummary(state);
+  }
+
+  summaryCache = { summary, generatedAt, stateKey, cachedAt: Date.now() };
+  return sendJson(res, 200, { summary, generatedAt, model: AI_KEY ? AI_MODEL : 'fallback' });
+}
+
+// --- Nudge system ---
+
+async function handleNudge(req, res) {
+  const raw = await readBody(req);
+  let body;
+  try { body = raw ? JSON.parse(raw) : {}; } catch { return sendJson(res, 400, { error: 'invalid_json' }); }
+
+  const validTypes = ['status_request', 'priority_change', 'deadline_extension', 'instruction'];
+  if (!validTypes.includes(body.type)) return sendJson(res, 400, { error: 'invalid_type', validTypes });
+
+  const ts = body.ts || new Date().toISOString();
+  const nudgeId = `nudge-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const record = { nudgeId, type: body.type, targetId: body.targetId || null, message: body.message || '', ts, source: 'mission-control-ui' };
+
+  const dir = path.join(workspaceRoot, 'out', 'nudges');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.appendFileSync(path.join(dir, `${ts.slice(0, 10)}.jsonl`), `${JSON.stringify(record)}\n`);
+
+  sendJson(res, 200, { ok: true, nudgeId });
+}
+
 const server = http.createServer(async (req, res) => {
   const url = new URL(req.url || '/', `http://${req.headers.host || `127.0.0.1:${port}`}`);
   if (url.pathname === '/healthz') return sendJson(res, 200, { ok: true, service: 'mission-control', port });
   if (url.pathname === '/api/state' && req.method === 'GET') return sendJson(res, 200, getState());
   if (url.pathname === '/api/state' && req.method === 'POST') return handleStatePush(req, res);
+  if (url.pathname === '/api/summary' && req.method === 'GET') return handleSummary(req, res);
+  if (url.pathname === '/api/nudge' && req.method === 'POST') return handleNudge(req, res);
 
   const approvalMatch = /^\/api\/approvals\/([^/]+)\/resolve$/.exec(url.pathname);
   if (req.method === 'POST' && approvalMatch) return handleApprovalResolve(req, res, decodeURIComponent(approvalMatch[1]));

--- a/server.mjs
+++ b/server.mjs
@@ -16,6 +16,9 @@ const PUSH_TTL_MS = 10 * 60 * 1000;
 let pushedState = null;
 let pushedAt = 0;
 
+// Nudge transport config — nudges are disabled until a real transport is configured
+const NUDGE_ENDPOINT = process.env.MC_NUDGE_ENDPOINT || null;
+
 // AI summary config
 const AI_KEY = process.env.MC_AI_KEY || null;
 const AI_MODEL = process.env.MC_AI_MODEL || 'gemini-2.5-flash';
@@ -224,6 +227,10 @@ async function handleSummary(req, res) {
 // --- Nudge system ---
 
 async function handleNudge(req, res) {
+  if (!NUDGE_ENDPOINT) {
+    return sendJson(res, 501, { error: 'nudge_not_configured', message: 'Set MC_NUDGE_ENDPOINT to enable nudges.' });
+  }
+
   const raw = await readBody(req);
   let body;
   try { body = raw ? JSON.parse(raw) : {}; } catch { return sendJson(res, 400, { error: 'invalid_json' }); }
@@ -235,6 +242,26 @@ async function handleNudge(req, res) {
   const nudgeId = `nudge-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const record = { nudgeId, type: body.type, targetId: body.targetId || null, message: body.message || '', ts, source: 'mission-control-ui' };
 
+  // Forward to configured transport endpoint
+  try {
+    const payload = JSON.stringify(record);
+    const parsed = new URL(NUDGE_ENDPOINT);
+    const proto = parsed.protocol === 'https:' ? https : http;
+    await new Promise((resolve, reject) => {
+      const fwd = proto.request(parsed, { method: 'POST', headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) } }, (fwdRes) => {
+        fwdRes.resume();
+        fwdRes.on('end', resolve);
+      });
+      fwd.on('error', reject);
+      fwd.setTimeout(10000, () => { fwd.destroy(); reject(new Error('nudge transport timeout')); });
+      fwd.write(payload);
+      fwd.end();
+    });
+  } catch (err) {
+    return sendJson(res, 502, { error: 'nudge_transport_failed', message: err.message });
+  }
+
+  // Also log locally for audit
   const dir = path.join(workspaceRoot, 'out', 'nudges');
   fs.mkdirSync(dir, { recursive: true });
   fs.appendFileSync(path.join(dir, `${ts.slice(0, 10)}.jsonl`), `${JSON.stringify(record)}\n`);
@@ -245,7 +272,12 @@ async function handleNudge(req, res) {
 const server = http.createServer(async (req, res) => {
   const url = new URL(req.url || '/', `http://${req.headers.host || `127.0.0.1:${port}`}`);
   if (url.pathname === '/healthz') return sendJson(res, 200, { ok: true, service: 'mission-control', port });
-  if (url.pathname === '/api/state' && req.method === 'GET') return sendJson(res, 200, getState());
+  if (url.pathname === '/api/state' && req.method === 'GET') {
+    const s = getState();
+    s.meta = s.meta || {};
+    s.meta.nudgeEnabled = !!NUDGE_ENDPOINT;
+    return sendJson(res, 200, s);
+  }
   if (url.pathname === '/api/state' && req.method === 'POST') return handleStatePush(req, res);
   if (url.pathname === '/api/summary' && req.method === 'GET') return handleSummary(req, res);
   if (url.pathname === '/api/nudge' && req.method === 'POST') return handleNudge(req, res);

--- a/styles.css
+++ b/styles.css
@@ -50,7 +50,22 @@
   100% { background-position: 200% 0; }
 }
 
+@keyframes attention-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
+
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  25% { transform: translateX(-3px); }
+  50% { transform: translateX(3px); }
+  75% { transform: translateX(-3px); }
+}
+
 .fade-in { animation: fadeIn 200ms ease; }
+.shake { animation: shake 200ms ease 3; }
+.needs-me-active { animation: attention-pulse 2s ease-in-out 15; /* ~30s then stops */ }
+
 * { box-sizing: border-box; transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease; }
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { animation: none !important; transition: none !important; }
@@ -83,9 +98,8 @@ code {
   color: var(--text-secondary);
 }
 
-.app-shell {
-  min-height: 100vh;
-}
+/* ─── Layout Shell ─── */
+.app-shell { min-height: 100vh; }
 
 .sidebar {
   position: fixed;
@@ -101,289 +115,92 @@ code {
   padding: var(--space-6) var(--space-4) var(--space-4);
 }
 
-.sidebar-top,
-.sidebar-bottom {
-  display: flex;
-  flex-direction: column;
-}
-
-.brand {
-  display: flex;
-  align-items: center;
-  gap: var(--space-3);
-  margin-bottom: var(--space-6);
-}
-
+.sidebar-top, .sidebar-bottom { display: flex; flex-direction: column; }
+.brand { display: flex; align-items: center; gap: var(--space-3); margin-bottom: var(--space-6); }
 .brand-mark {
-  width: 24px;
-  height: 24px;
-  border-radius: var(--radius-md);
-  background: var(--accent);
-  color: #fff;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 12px;
-  font-weight: 600;
+  width: 24px; height: 24px; border-radius: var(--radius-md); background: var(--accent);
+  color: #fff; display: inline-flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 600;
 }
-
-.brand-title {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.brand-subtitle {
-  font-size: 11px;
-  font-weight: 400;
-  color: var(--text-tertiary);
-}
-
-.sidebar-source-count {
-  font-size: 12px;
-  color: var(--text-tertiary);
-  margin-bottom: var(--space-4);
-}
-
-.nav-group-label {
-  margin: 16px 0 8px;
-  padding-left: 12px;
-  color: var(--text-tertiary);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
-.sidebar-nav {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
+.brand-title { font-size: 14px; font-weight: 600; color: var(--text-primary); }
+.brand-subtitle { font-size: 11px; font-weight: 400; color: var(--text-tertiary); }
+.sidebar-source-count { font-size: 12px; color: var(--text-tertiary); margin-bottom: var(--space-4); }
+.sidebar-nav { display: flex; flex-direction: column; gap: 2px; }
 
 .nav-item {
-  height: 32px;
-  padding: 8px 12px;
-  border-radius: var(--radius-md);
-  border: 0;
-  border-left: 2px solid transparent;
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: 13px;
-  font-weight: 500;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  cursor: pointer;
-  text-align: left;
+  height: 32px; padding: 8px 12px; border-radius: var(--radius-md); border: 0;
+  border-left: 2px solid transparent; background: transparent; color: var(--text-secondary);
+  font-size: 13px; font-weight: 500; display: flex; align-items: center; gap: 8px;
+  cursor: pointer; text-align: left; position: relative;
+}
+.nav-item:hover { background: var(--bg-overlay); color: var(--text-primary); }
+.nav-item.is-active { background: var(--accent-subtle); color: var(--accent-text); border-left-color: var(--accent); }
+.nav-icon { width: 16px; color: var(--text-tertiary); flex: 0 0 16px; text-align: center; }
+.nav-item:hover .nav-icon, .nav-item.is-active .nav-icon { color: currentColor; }
+.nav-dot {
+  width: 6px; height: 6px; border-radius: 50%; background: var(--warning);
+  position: absolute; right: 12px; top: 50%; transform: translateY(-50%);
 }
 
-.nav-item:hover {
-  background: var(--bg-overlay);
-  color: var(--text-primary);
-}
+.sidebar-divider { height: 1px; background: var(--border-default); margin: 0 0 var(--space-4); }
+.agent-indicator { display: flex; align-items: center; gap: 6px; color: var(--text-secondary); margin-bottom: var(--space-4); }
 
-.nav-item.is-active {
-  background: var(--accent-subtle);
-  color: var(--accent-text);
-  border-left-color: var(--accent);
-}
-
-.nav-icon {
-  width: 16px;
-  color: var(--text-tertiary);
-  flex: 0 0 16px;
-  text-align: center;
-}
-
-.nav-item:hover .nav-icon,
-.nav-item.is-active .nav-icon {
-  color: currentColor;
-}
-
-.sidebar-divider {
-  height: 1px;
-  background: var(--border-default);
-  margin: 0 0 var(--space-4);
-}
-
-.agent-indicator {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  color: var(--text-secondary);
-  margin-bottom: var(--space-4);
-}
-
-.main {
-  margin-left: 240px;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-}
+.main { margin-left: 240px; min-height: 100vh; display: flex; flex-direction: column; }
 
 .header-bar {
-  position: sticky;
-  top: 0;
-  z-index: 20;
-  height: 48px;
-  background: rgba(17,17,19,0.8);
-  backdrop-filter: blur(12px);
+  position: sticky; top: 0; z-index: 20; height: 48px;
+  background: rgba(17,17,19,0.8); backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--border-default);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-4);
-  padding: 0 var(--space-6);
+  display: flex; align-items: center; justify-content: space-between; gap: var(--space-4); padding: 0 var(--space-6);
 }
-
-.header-left,
-.header-right {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 0;
-}
-
+.header-left, .header-right { display: flex; align-items: center; gap: 8px; min-width: 0; }
 .header-left { flex-direction: column; align-items: flex-start; gap: 0; }
-.header-tagline {
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--text-tertiary);
-  line-height: 1.1;
-}
-.header-title {
-  margin: 0;
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--text-primary);
-  line-height: 1.2;
-}
+.header-tagline { font-size: 11px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-tertiary); line-height: 1.1; }
+.header-title { margin: 0; font-size: 16px; font-weight: 600; color: var(--text-primary); line-height: 1.2; }
 
 .header-pill {
-  display: inline-flex;
-  align-items: center;
-  min-height: 26px;
-  padding: 4px 12px;
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius-full);
-  color: var(--text-tertiary);
-  font-size: 12px;
-  font-weight: 500;
-  white-space: nowrap;
+  display: inline-flex; align-items: center; min-height: 26px; padding: 4px 12px;
+  border: 1px solid var(--border-default); border-radius: var(--radius-full);
+  color: var(--text-tertiary); font-size: 12px; font-weight: 500; white-space: nowrap;
 }
+.header-pill-alert { background: var(--error-bg); color: var(--error); border-color: rgba(229,72,77,0.3); font-weight: 600; }
 
-.header-pill-alert {
-  background: var(--error-bg);
-  color: var(--error);
-  border-color: rgba(229,72,77,0.3);
-  font-weight: 600;
-}
+.content-wrap { width: 100%; padding: 24px; }
+.view { max-width: 1400px; display: flex; flex-direction: column; gap: var(--space-6); }
 
-.content-wrap {
-  width: 100%;
-  padding: 24px;
-}
-
-.view {
-  max-width: 1400px;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-6);
-}
-
-.grid {
-  display: grid;
-  gap: var(--space-4);
-}
+/* ─── Grid ─── */
+.grid { display: grid; gap: var(--space-4); }
 .grid-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 .grid-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
 .grid-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
 
+/* ─── Card ─── */
 .card {
-  background: var(--bg-surface);
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius-lg);
-  padding: 16px;
+  background: var(--bg-surface); border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg); padding: 16px;
 }
+.card-interactive:hover, .kpi-card:hover, .task-card:hover, .approval-card:hover, .artifact-card:hover, .agent-card:hover { border-color: var(--border-strong); }
+.kpi-card:hover { box-shadow: var(--shadow-sm); }
+.card-header { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); margin-bottom: var(--space-4); }
+.card-header h3 { margin: 0; font-size: 16px; font-weight: 600; color: var(--text-primary); }
+.card-subtitle { font-size: 12px; color: var(--text-tertiary); }
 
-.card-interactive:hover,
-.kpi-card:hover,
-.task-card:hover,
-.approval-card:hover,
-.artifact-card:hover,
-.agent-card:hover {
-  border-color: var(--border-strong);
-}
-
-.kpi-card:hover {
-  box-shadow: var(--shadow-sm);
-}
-
-.card-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
-  margin-bottom: var(--space-4);
-}
-
-.card-header h3 {
-  margin: 0;
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.card-subtitle {
-  font-size: 12px;
-  color: var(--text-tertiary);
-}
-
-.kpi-grid {
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-.kpi-label {
-  margin: 0 0 8px;
-  color: var(--text-tertiary);
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-.metric-value {
-  color: var(--text-primary);
-  font-size: 28px;
-  font-weight: 600;
-  letter-spacing: -0.02em;
-  line-height: 1.1;
-  margin-bottom: 8px;
-}
-
+/* ─── KPI Cards (Settings) ─── */
+.kpi-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.kpi-label { margin: 0 0 8px; color: var(--text-tertiary); font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }
+.metric-value { color: var(--text-primary); font-size: 28px; font-weight: 600; letter-spacing: -0.02em; line-height: 1.1; margin-bottom: 8px; }
 .metric-value.is-money { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
-.kpi-description {
-  color: var(--text-tertiary);
-  font-size: 12px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
+.kpi-description { color: var(--text-tertiary); font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.kpi-card--info { border-left: 3px solid var(--info); }
+.kpi-card--success { border-left: 3px solid var(--success); }
+.kpi-card--warning { border-left: 3px solid var(--warning); }
+.kpi-card--error { border-left: 3px solid var(--error); }
+.kpi-card--accent { border-left: 3px solid var(--accent); }
 
+/* ─── Badge ─── */
 .badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 2px 8px;
-  border-radius: var(--radius-sm);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  white-space: nowrap;
+  display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px;
+  border-radius: var(--radius-sm); font-size: 11px; font-weight: 600;
+  letter-spacing: 0.04em; text-transform: uppercase; white-space: nowrap;
 }
 .badge-success { color: var(--success); background: var(--success-bg); }
 .badge-warning { color: var(--warning); background: var(--warning-bg); }
@@ -391,683 +208,583 @@ code {
 .badge-info { color: var(--info); background: var(--info-bg); }
 .badge-default { color: var(--accent-text); background: var(--accent-subtle); }
 
-.truth-dot {
-  display: inline-block;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  margin-right: 4px;
-  vertical-align: middle;
-}
+/* ─── Truth dots ─── */
+.truth-dot { display: inline-block; width: 6px; height: 6px; border-radius: 50%; margin-right: 4px; vertical-align: middle; }
 .truth-verified { background: var(--success); }
 .truth-claimed { background: var(--warning); }
 .truth-stale { background: var(--error); }
 .truth-unknown { background: var(--text-tertiary); }
 
-.truth-inline,
-.inline-meta,
-.inline-list,
-.lane-pill-row,
-.badge-row,
-.action-row,
-.key-value-grid,
-.empty-state,
-.events-list,
-.memory-list,
-.spec-source-list,
-.agent-meta,
-.approval-meta,
-.artifact-meta,
-.table-meta {
-  display: flex;
-}
+/* ─── Misc layout ─── */
+.truth-inline, .inline-meta, .inline-list, .lane-pill-row, .badge-row, .action-row, .key-value-grid, .empty-state, .events-list, .memory-list, .spec-source-list, .agent-meta, .approval-meta, .artifact-meta, .table-meta { display: flex; }
+.inline-list, .lane-pill-row, .badge-row, .action-row, .spec-source-list { flex-wrap: wrap; gap: 8px; }
+.lane-pill, .count-pill { display: inline-flex; align-items: center; gap: 6px; min-height: 24px; padding: 4px 10px; border-radius: var(--radius-full); background: var(--bg-elevated); color: var(--text-secondary); font-size: 12px; font-weight: 500; }
 
-.problem-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-}
+.list-item-title, .problem-title, .task-title, .approval-title, .agent-name, .artifact-title, .event-summary { color: var(--text-primary); font-weight: 500; }
+.list-item-copy, .problem-copy, .approval-reason, .agent-role, .artifact-value, .event-meta, .empty-copy { color: var(--text-secondary); font-size: 13px; }
 
-.inline-list,
-.lane-pill-row,
-.badge-row,
-.action-row,
-.spec-source-list {
-  flex-wrap: wrap;
-  gap: 8px;
-}
+.split-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 
-.truth-stat {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  color: var(--text-secondary);
-  font-size: 13px;
-}
+/* ─── Kanban (Work) ─── */
+.kanban-board { grid-template-columns: repeat(6, minmax(220px, 1fr)); align-items: start; overflow-x: auto; padding-bottom: 2px; }
+.lane-column { min-width: 220px; }
+.task-stack { display: flex; flex-direction: column; gap: 12px; }
+.task-card { background: var(--bg-elevated); border: 1px solid var(--border-default); border-radius: var(--radius-lg); padding: 14px; }
+.task-header, .approval-header, .agent-header, .artifact-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 8px; margin-bottom: 10px; }
+.task-title { font-size: 13px; font-weight: 500; margin: 0; }
+.source-ref, .mono, .event-time, .table-mono, .path-mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
+.source-ref, .event-time, .path-mono { font-size: 11px; color: var(--text-tertiary); }
+.empty-state { min-height: 120px; align-items: center; justify-content: center; border: 1px dashed var(--border-strong); border-radius: var(--radius-lg); background: var(--bg-elevated); text-align: center; padding: var(--space-6); }
+.empty-state-compact { min-height: 96px; }
 
-.lane-pill,
-.count-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  min-height: 24px;
-  padding: 4px 10px;
-  border-radius: var(--radius-full);
-  background: var(--bg-elevated);
-  color: var(--text-secondary);
-  font-size: 12px;
-  font-weight: 500;
-}
+/* ─── Key-Value ─── */
+.key-value-grid { display: grid; grid-template-columns: 120px 1fr; gap: 8px 12px; margin-top: 12px; }
+.key-label { color: var(--text-tertiary); font-size: 12px; }
+.key-value { color: var(--text-primary); font-size: 13px; }
 
-.list-plain {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.list-plain li + li,
-.events-list-item + .events-list-item,
-.problem-item + .problem-item,
-.memory-list li + li,
-.approval-card + .approval-card {
-  margin-top: 12px;
-}
-
-.list-item-title,
-.problem-title,
-.task-title,
-.approval-title,
-.agent-name,
-.artifact-title,
-.event-summary {
-  color: var(--text-primary);
-  font-weight: 500;
-}
-
-.list-item-copy,
-.problem-copy,
-.approval-reason,
-.agent-role,
-.artifact-value,
-.event-meta,
-.empty-copy {
-  color: var(--text-secondary);
-  font-size: 13px;
-}
-
-.split-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.kanban-board {
-  grid-template-columns: repeat(6, minmax(220px, 1fr));
-  align-items: start;
-  overflow-x: auto;
-  padding-bottom: 2px;
-}
-
-.lane-column {
-  min-width: 220px;
-}
-
-.task-stack {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.task-card {
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius-lg);
-  padding: 14px;
-}
-
-.task-header,
-.approval-header,
-.agent-header,
-.artifact-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 8px;
-  margin-bottom: 10px;
-}
-
-.task-title {
-  font-size: 13px;
-  font-weight: 500;
-  margin: 0;
-}
-
-.source-ref,
-.mono,
-.event-time,
-.table-mono,
-.path-mono {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
-}
-
-.source-ref,
-.event-time,
-.path-mono {
-  font-size: 11px;
-  color: var(--text-tertiary);
-}
-
-.empty-state {
-  min-height: 120px;
-  align-items: center;
-  justify-content: center;
-  border: 1px dashed var(--border-strong);
-  border-radius: var(--radius-lg);
-  background: var(--bg-elevated);
-  text-align: center;
-  padding: var(--space-6);
-}
-
-.empty-state-compact {
-  min-height: 96px;
-}
-
-.approvals-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.approval-card .approval-consequence {
-  margin-top: 12px;
-  background: var(--bg-elevated);
-  border-left: 2px solid var(--warning);
-  padding: 8px 12px;
-  border-radius: var(--radius-sm);
-  color: var(--text-secondary);
-  font-size: 13px;
-}
-
-.key-value-grid {
-  display: grid;
-  grid-template-columns: 120px 1fr;
-  gap: 8px 12px;
-  margin-top: 12px;
-}
-.key-label {
-  color: var(--text-tertiary);
-  font-size: 12px;
-}
-.key-value {
-  color: var(--text-primary);
-  font-size: 13px;
-}
-
+/* ─── Buttons ─── */
 .btn {
-  height: 32px;
-  padding: 0 12px;
-  border-radius: var(--radius-md);
-  border: 1px solid transparent;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
+  height: 32px; padding: 0 12px; border-radius: var(--radius-md); border: 1px solid transparent;
+  font-size: 13px; font-weight: 500; cursor: pointer; display: inline-flex; align-items: center;
+  justify-content: center; gap: 6px;
 }
 .btn:hover { filter: none; }
-.btn:active { transform: scale(0.98); }
-.btn:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px #111113, 0 0 0 4px #6E56CF;
-}
-.btn-primary {
-  background: var(--accent);
-  color: #fff;
-}
+.btn:active { transform: scale(0.95); }
+.btn:focus-visible { outline: none; box-shadow: 0 0 0 2px #111113, 0 0 0 4px #6E56CF; }
+.btn-primary { background: var(--accent); color: #fff; }
 .btn-primary:hover { background: var(--accent-hover); }
-.btn-secondary {
-  background: transparent;
-  border-color: var(--border-default);
-  color: var(--text-secondary);
-}
-.btn-secondary:hover {
-  background: var(--bg-overlay);
-  color: var(--text-primary);
-}
-.btn-destructive {
-  background: transparent;
-  border-color: rgba(229,72,77,0.3);
-  color: var(--error);
-}
+.btn-secondary { background: transparent; border-color: var(--border-default); color: var(--text-secondary); }
+.btn-secondary:hover { background: var(--bg-overlay); color: var(--text-primary); }
+.btn-destructive { background: transparent; border-color: rgba(229,72,77,0.3); color: var(--error); }
 .btn-destructive:hover { background: var(--error-bg); }
-.btn-success {
-  background: var(--success);
-  color: #fff;
-}
+.btn-success { background: var(--success); color: #fff; }
 .btn-success:hover { background: #38b879; }
+.btn-sm { height: 28px; font-size: 12px; padding: 0 10px; }
+.btn-nudge-sent { background: var(--success-bg); color: var(--success); border-color: transparent; }
 .sidebar-refresh { width: 100%; }
 
-/* Simple event list (used in Overview) */
-.event-simple-list { flex-direction: column; gap: 0; }
-.event-simple-item {
-  padding: 10px 0;
-  border-bottom: 1px solid var(--bg-elevated);
-}
-.event-simple-item:last-child { border-bottom: none; }
-.event-simple-meta {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 4px;
-}
-.event-simple-summary {
-  color: var(--text-primary);
-  font-size: 13px;
-  font-weight: 500;
-  line-height: 1.4;
-  margin-bottom: 2px;
-}
-.event-simple-actor {
-  color: var(--text-tertiary);
-  font-size: 11px;
-}
-
-.events-card {
-  max-height: calc(100vh - 180px);
-  overflow: auto;
-}
-.events-list {
-  flex-direction: column;
-}
-.events-list-item {
-  display: grid;
-  grid-template-columns: 170px 140px 140px minmax(220px, 1fr) auto auto;
-  gap: 12px;
-  align-items: center;
-  padding: 12px 0;
-  border-bottom: 1px solid var(--bg-elevated);
-}
-.events-list-item:last-child { border-bottom: 0; }
-.event-summary { font-size: 14px; }
-.event-meta { gap: 8px; align-items: center; }
-
-.agent-grid {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-.agent-role { margin: 0 0 12px; }
-.agent-meta {
-  flex-direction: column;
-  gap: 10px;
-}
-
-.table-wrap {
-  overflow-x: auto;
-}
-.table {
-  width: 100%;
-  border-collapse: collapse;
-}
-.table th {
-  padding: 8px 16px;
-  border-bottom: 1px solid var(--border-default);
-  text-align: left;
-  color: var(--text-tertiary);
-  font-size: 12px;
-  font-weight: 500;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-.table td {
-  padding: 10px 16px;
-  border-bottom: 1px solid var(--bg-elevated);
-  color: var(--text-secondary);
-  font-size: 13px;
-  height: 40px;
-  vertical-align: top;
-}
-.table tr:hover td { background: var(--bg-overlay); }
-.table-strong {
-  color: var(--text-primary);
-  font-weight: 500;
-}
-
-.artifacts-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.memory-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-.memory-block + .memory-block { margin-top: 16px; }
-.memory-block-title {
-  margin: 0 0 8px;
-  color: var(--text-primary);
-  font-size: 13px;
-  font-weight: 500;
-}
-.memory-list {
-  flex-direction: column;
-  gap: 8px;
-  padding-left: 18px;
-  margin: 0;
-}
-.memory-list li { color: var(--text-secondary); }
-
-.spec-source-list code { color: var(--text-secondary); }
-.mission-copy {
-  color: var(--text-secondary);
-  margin: 0;
-}
-.confirmation-inline {
-  margin-top: 10px;
-  color: var(--success);
-  font-size: 12px;
-  font-weight: 500;
-}
-.error-inline {
-  margin-top: 10px;
-  color: var(--error);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-
-.freshness-dot {
-  display: inline-block;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  margin-right: 6px;
-  vertical-align: middle;
-}
+/* ─── Freshness ─── */
+.freshness-dot { display: inline-block; width: 6px; height: 6px; border-radius: 50%; margin-right: 6px; vertical-align: middle; }
 .freshness-fresh { background: var(--success); }
 .freshness-aging { background: var(--warning); }
 .freshness-stale { background: var(--error); }
 
-.status-banner {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  border: 1px solid var(--border-default);
-  border-radius: var(--radius-lg);
-  padding: 16px;
-}
-.status-banner--ok { background: rgba(48, 164, 108, 0.08); }
-.status-banner--attention { background: rgba(245, 166, 35, 0.08); }
-.status-banner--stalled { background: rgba(229, 72, 77, 0.08); }
-.status-banner--offline { background: var(--bg-elevated); }
-.status-banner__top,
-.status-banner__footer,
-.status-banner__meta,
-.current-work-item,
-.activity-row,
-.commitment-row,
-.delivery-history-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
-.status-banner__key { color: var(--text-secondary); font-weight: 500; }
-.status-banner__line,
-.status-banner__meta,
-.status-banner__footer { color: var(--text-primary); }
-.status-banner__age,
-.status-banner__meta { color: var(--text-secondary); }
-
-.kpi-card--info { border-left: 3px solid var(--info); }
-.kpi-card--success { border-left: 3px solid var(--success); }
-.kpi-card--warning { border-left: 3px solid var(--warning); }
-.kpi-card--error { border-left: 3px solid var(--error); }
-.kpi-card--accent { border-left: 3px solid var(--accent); }
-
-.commitment-list,
-.current-work-list,
-.activity-list,
-.compact-approval-list { display: flex; flex-direction: column; gap: 12px; }
-.commitment-row,
-.current-work-item,
-.activity-row,
-.compact-approval-item,
-.delivery-history-row {
-  border-bottom: 1px solid var(--bg-elevated);
-  padding-bottom: 12px;
-}
-.commitment-row:last-child,
-.current-work-item:last-child,
-.activity-row:last-child,
-.compact-approval-item:last-child,
+/* ─── Delivery History (Agents) ─── */
+.delivery-history { margin-top: 16px; border-top: 1px solid var(--bg-elevated); padding-top: 16px; }
+.delivery-history-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; border-bottom: 1px solid var(--bg-elevated); padding-bottom: 12px; }
 .delivery-history-row:last-child { border-bottom: none; padding-bottom: 0; }
-.commitment-row__main { min-width: 0; }
-.commitment-row__title,
-.problem-toggle__title,
-.delivery-history-row__title { display: flex; align-items: center; gap: 8px; color: var(--text-primary); font-weight: 500; }
-.commitment-row__context,
-.compact-approval-item__meta,
-.problem-next { color: var(--text-secondary); font-size: 13px; }
-.commitment-countdown,
-.activity-row__time,
-.delivery-history-row__date,
-.delivery-history-row__time { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace; color: var(--text-secondary); }
-.commitment-row--delivered .commitment-countdown { color: var(--success); }
-.commitment-row--at_risk .commitment-countdown,
-.commitment-row--at-risk .commitment-countdown { color: var(--warning); }
-.commitment-row--missed .commitment-countdown { color: var(--error); }
+.delivery-history-row__title { display: flex; align-items: center; gap: 8px; color: var(--text-primary); font-weight: 500; flex: 1; min-width: 0; }
+.delivery-history-row__date, .delivery-history-row__time { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace; color: var(--text-secondary); }
+.memory-block-title { margin: 0 0 8px; color: var(--text-primary); font-size: 13px; font-weight: 500; }
 
-.scorecard-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
-}
-.scorecard-row--success { color: var(--success); }
-.scorecard-row--warning { color: var(--warning); }
-.scorecard-row--error { color: var(--error); }
+/* ─── Agents ─── */
+.agent-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.agent-role { margin: 0 0 12px; }
+.agent-meta { flex-direction: column; gap: 10px; }
 
-.current-work-item__dot {
-  width: 8px; height: 8px; border-radius: 50%; background: var(--info); flex: 0 0 8px;
-}
-.current-work-item__title,
-.activity-row__summary { min-width: 0; flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+/* ─── Table ─── */
+.table-wrap { overflow-x: auto; }
+.table { width: 100%; border-collapse: collapse; }
+.table th { padding: 8px 16px; border-bottom: 1px solid var(--border-default); text-align: left; color: var(--text-tertiary); font-size: 12px; font-weight: 500; letter-spacing: 0.04em; text-transform: uppercase; }
+.table td { padding: 10px 16px; border-bottom: 1px solid var(--bg-elevated); color: var(--text-secondary); font-size: 13px; height: 40px; vertical-align: top; }
+.table tr:hover td { background: var(--bg-overlay); }
+.table-strong { color: var(--text-primary); font-weight: 500; }
+
+.spec-source-list { flex-wrap: wrap; gap: 6px; }
+.spec-source-list code { color: var(--text-secondary); }
+
+.confirmation-inline { margin-top: 10px; color: var(--success); font-size: 12px; font-weight: 500; }
+.error-inline { margin-top: 10px; color: var(--error); font-size: 12px; font-weight: 500; }
+
 .section-footer { margin-top: 12px; display: flex; justify-content: flex-end; }
 .link-button { background: none; border: none; color: var(--accent-text); padding: 0; cursor: pointer; font-size: 13px; }
 .link-button:hover { color: var(--text-primary); }
 
-.problem-card { padding: 10px 0; border-bottom: 1px solid var(--bg-elevated); }
-.problem-card:last-child { border-bottom: none; }
-.problem-toggle {
-  width: 100%; background: none; border: none; color: inherit; padding: 0; cursor: pointer; text-align: left;
-  display: flex; align-items: center; justify-content: space-between;
+/* ═══════════════════════════════════════════
+   V5 — Hero, KPI Row, Sections, Timeline
+   ═══════════════════════════════════════════ */
+
+/* --- AI Summary Hero --- */
+.v5-hero {
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-xl);
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
-.problem-toggle::after { content: '▾'; color: var(--text-tertiary); }
-.problem-card.expanded .problem-toggle::after { content: '▴'; }
-.problem-description,
-.problem-next { display: none; margin-top: 8px; }
-.problem-card.expanded .problem-description,
-.problem-card.expanded .problem-next { display: block; }
+.v5-hero--ok { background: linear-gradient(180deg, rgba(48,164,108,0.03) 0%, transparent 100%), var(--bg-elevated); }
+.v5-hero--attention { background: linear-gradient(180deg, rgba(245,166,35,0.04) 0%, transparent 100%), var(--bg-elevated); }
+.v5-hero--stalled { background: linear-gradient(180deg, rgba(229,72,77,0.04) 0%, transparent 100%), var(--bg-elevated); }
+.v5-hero--offline { background: var(--bg-elevated); }
 
-.activity-row__time { width: 130px; flex: 0 0 130px; }
-.delivery-history { margin-top: 16px; border-top: 1px solid var(--bg-elevated); padding-top: 16px; }
-.delivery-history-row__title { flex: 1; min-width: 0; }
+.v5-hero__greeting { font-size: 16px; font-weight: 600; color: var(--text-primary); }
+.v5-hero__summary { font-size: 15px; font-weight: 400; color: var(--text-primary); line-height: 1.6; }
+.v5-hero__status { font-size: 14px; color: var(--text-secondary); }
+.v5-hero__meta { font-size: 12px; color: var(--text-tertiary); }
 
+/* Skeleton shimmer */
+.skeleton-line {
+  height: 16px;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(90deg, var(--bg-overlay) 25%, var(--bg-subtle) 50%, var(--bg-overlay) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s ease-in-out infinite;
+  margin-bottom: 8px;
+}
+.skeleton-line--short { width: 60%; }
 
-/* ─── 1280px: wide desktop collapse ─── */
+/* --- V5 KPI Row --- */
+.v5-kpi-row {
+  display: flex;
+  gap: 0;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  background: var(--bg-surface);
+  overflow: hidden;
+}
+.v5-kpi {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 12px 8px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-primary);
+}
+.v5-kpi:not(:last-child) { border-right: 1px solid var(--border-default); }
+.v5-kpi:hover { background: var(--bg-elevated); }
+.v5-kpi__value { font-size: 20px; font-weight: 600; font-variant-numeric: tabular-nums; }
+.v5-kpi__value--money { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
+.v5-kpi__label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-tertiary); }
+
+/* --- V5 Section --- */
+.v5-section {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+}
+.v5-section__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-3);
+}
+.v5-section__title {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+}
+.v5-section__stat {
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+.v5-section__footer-stats {
+  display: flex;
+  gap: 16px;
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--bg-elevated);
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+/* --- Commitments Widget --- */
+.v5-commitment-list { display: flex; flex-direction: column; gap: 0; }
+.v5-commitment-row {
+  padding: 10px 0;
+  border-bottom: 1px solid var(--bg-elevated);
+}
+.v5-commitment-row:last-child { border-bottom: none; }
+.v5-commitment-row__main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+.v5-commitment-icon {
+  flex: 0 0 20px;
+  text-align: center;
+  font-size: 14px;
+}
+.v5-commitment-icon--delivered { color: var(--success); }
+.v5-commitment-icon--missed { color: var(--error); }
+.v5-commitment-icon--at_risk { color: var(--warning); }
+.v5-commitment-icon--in_progress { color: var(--info); }
+.v5-commitment-title {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text-primary);
+  font-weight: 500;
+  font-size: 14px;
+}
+.v5-commitment-time {
+  flex: 0 0 auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.v5-commitment-row--delivered .v5-commitment-time { color: var(--success); }
+.v5-commitment-row--at_risk .v5-commitment-time { color: var(--warning); }
+.v5-commitment-row--missed .v5-commitment-time { color: var(--error); }
+.v5-commitment-row--at_risk { background: rgba(245,166,35,0.04); border-radius: var(--radius-sm); padding-left: 8px; padding-right: 8px; }
+
+.v5-commitment-detail {
+  margin-top: 8px;
+  padding-left: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  animation: fadeIn 200ms ease;
+}
+.v5-commitment-context { font-size: 13px; color: var(--text-secondary); }
+.v5-commitment-proof { font-size: 12px; color: var(--text-tertiary); }
+.v5-commitment-dates { font-size: 11px; color: var(--text-tertiary); font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace; }
+.v5-commitment-actions { display: flex; gap: 8px; margin-top: 4px; }
+
+/* --- Active Work --- */
+.v5-work-list { display: flex; flex-direction: column; gap: 0; }
+.v5-work-item {
+  padding: 10px 0;
+  border-bottom: 1px solid var(--bg-elevated);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+.v5-work-item:last-child { border-bottom: none; }
+.v5-work-item__main { display: flex; align-items: center; gap: 8px; flex: 1; min-width: 0; }
+.v5-work-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--info); flex: 0 0 8px; }
+.v5-work-title {
+  flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  color: var(--text-primary); font-weight: 500; font-size: 14px;
+}
+.v5-work-meta { font-size: 12px; color: var(--text-tertiary); width: 100%; padding-left: 16px; }
+.v5-nudge-inline { flex: 0 0 auto; }
+
+/* --- Needs Attention --- */
+.v5-attention-list { display: flex; flex-direction: column; gap: 0; }
+.v5-attention-item {
+  padding: 12px 0;
+  border-bottom: 1px solid var(--bg-elevated);
+}
+.v5-attention-item:last-child { border-bottom: none; }
+.v5-attention-item__header { display: flex; align-items: center; gap: 8px; cursor: pointer; }
+.v5-attention-dot { flex: 0 0 auto; font-size: 14px; }
+.v5-attention-item__title { color: var(--text-primary); font-weight: 500; font-size: 14px; }
+.v5-attention-item__desc { font-size: 13px; color: var(--text-secondary); margin-top: 4px; padding-left: 26px; }
+.v5-attention-detail { margin-top: 8px; padding-left: 26px; animation: fadeIn 200ms ease; }
+.v5-attention-recommend { font-size: 13px; color: var(--text-secondary); }
+.v5-attention-actions { display: flex; gap: 8px; margin-top: 8px; padding-left: 26px; }
+
+/* Notes form */
+.v5-notes-form { margin-top: 8px; padding-left: 26px; }
+.v5-notes-input {
+  width: 100%;
+  height: 32px;
+  padding: 0 10px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  font-size: 13px;
+}
+.v5-notes-input:focus { outline: none; border-color: var(--accent); }
+
+/* --- Timeline (Home) --- */
+.v5-timeline { display: flex; flex-direction: column; gap: 0; }
+.v5-timeline-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--bg-elevated);
+}
+.v5-timeline-row:last-child { border-bottom: none; }
+.v5-timeline-time {
+  flex: 0 0 90px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+  font-size: 12px;
+  color: var(--text-quaternary);
+}
+.v5-timeline-summary { flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: var(--text-primary); font-size: 13px; font-weight: 500; }
+.v5-timeline-icon { flex: 0 0 auto; font-size: 14px; color: var(--text-tertiary); }
+.v5-timeline-separator {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+  padding: 12px 0 4px;
+  border-bottom: 1px solid var(--bg-elevated);
+}
+
+/* --- Morning Digest --- */
+.v5-digest {
+  background: linear-gradient(180deg, rgba(245,166,35,0.06) 0%, transparent 100%), var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-xl);
+  padding: var(--space-6);
+  transition: opacity 200ms ease;
+}
+.v5-digest__header {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+  margin-bottom: var(--space-3);
+}
+.v5-digest__summary { font-size: 14px; color: var(--text-primary); line-height: 1.6; margin-bottom: var(--space-3); }
+.v5-digest__bullets { list-style: none; padding: 0; margin: 0 0 var(--space-4); display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: var(--text-secondary); }
+.v5-digest__action { display: flex; justify-content: flex-end; }
+
+/* --- V5 Empty state --- */
+.v5-empty { color: var(--text-tertiary); font-size: 13px; padding: 12px 0; text-align: center; }
+.v5-more { font-size: 12px; color: var(--text-tertiary); text-align: right; margin-top: 8px; }
+
+/* --- V5 Tabs (Activity, Settings) --- */
+.v5-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border-default);
+  margin-bottom: var(--space-4);
+}
+.v5-tab {
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-tertiary);
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: none;
+  cursor: pointer;
+}
+.v5-tab.active { color: var(--text-primary); border-bottom-color: var(--accent); }
+.v5-tab:hover { color: var(--text-secondary); }
+
+/* --- Activity View --- */
+.v5-activity-list { display: flex; flex-direction: column; gap: 0; }
+.v5-activity-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--bg-elevated);
+}
+.v5-activity-row:last-child { border-bottom: none; }
+.v5-activity-type-icon { flex: 0 0 20px; text-align: center; color: var(--text-tertiary); font-size: 14px; }
+.v5-activity-time {
+  flex: 0 0 120px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+.v5-activity-summary { flex: 1; min-width: 0; color: var(--text-primary); font-size: 13px; font-weight: 500; }
+
+/* --- Quick Command Bar --- */
+.v5-command-bar {
+  position: sticky;
+  bottom: 0;
+  z-index: 15;
+  background: var(--bg-surface);
+  border-top: 1px solid var(--border-default);
+  padding: 8px 16px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.v5-command-input {
+  flex: 1;
+  height: 36px;
+  padding: 0 12px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  font-size: 14px;
+}
+.v5-command-input::placeholder { color: var(--text-tertiary); }
+.v5-command-input:focus { outline: none; border-color: var(--accent); }
+.v5-command-send {
+  height: 36px;
+  padding: 0 14px;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+}
+.v5-command-send:hover { background: var(--accent-hover); }
+.v5-command-send:active { transform: scale(0.95); }
+.v5-command-feedback {
+  font-size: 12px;
+  color: var(--success);
+  opacity: 0;
+  transition: opacity 200ms ease;
+  white-space: nowrap;
+}
+.v5-command-feedback.visible { opacity: 1; }
+.v5-command-feedback.error { color: var(--error); }
+
+/* --- Pull to Refresh --- */
+.v5-pull-indicator {
+  display: none;
+  justify-content: center;
+  padding: 8px;
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+.v5-pull-indicator.visible { display: flex; }
+
+/* --- Desktop command bar in sidebar --- */
+.sidebar-command-bar {
+  margin-top: var(--space-3);
+}
+.sidebar-command-bar form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.sidebar-command-bar .v5-command-input {
+  width: 100%;
+  height: 32px;
+  font-size: 13px;
+}
+.sidebar-command-bar .v5-command-send {
+  width: 100%;
+  height: 28px;
+  font-size: 12px;
+}
+.sidebar-command-bar .v5-command-feedback {
+  text-align: center;
+}
+
+/* ═══════════════════════════════════════════
+   Responsive Breakpoints
+   ═══════════════════════════════════════════ */
+
+/* ─── 1280px ─── */
 @media (max-width: 1280px) {
   .kpi-grid, .agent-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .events-list-item { grid-template-columns: 150px 120px 120px minmax(180px, 1fr) auto auto; }
 }
 
 /* ─── 1100px: icon-only sidebar ─── */
 @media (max-width: 1100px) {
   .sidebar { width: 48px; overflow: hidden; }
-  .sidebar .brand-copy,
-  .sidebar .sidebar-source-count,
-  .sidebar .nav-item-label,
-  .sidebar .nav-section-label,
-  .sidebar .sidebar-bottom { display: none; }
+  .sidebar .brand-copy, .sidebar .sidebar-source-count, .sidebar .nav-item-label,
+  .sidebar .nav-section-label, .sidebar .sidebar-bottom { display: none; }
   .sidebar .nav-item { padding: 8px; justify-content: center; }
   .main { margin-left: 48px; }
   .kanban-board { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
-/* ─── 768px: mobile drawer + touch targets ─── */
+/* ─── 768px: mobile drawer + single column ─── */
 .hamburger-btn { display: none; }
-.sidebar-overlay {
-  display: none;
-  position: fixed;
-  inset: 0;
-  background: rgba(0,0,0,0.5);
-  z-index: 99;
-}
+.sidebar-overlay { display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 99; }
 .sidebar-overlay.visible { display: block; }
 
 @media (max-width: 768px) {
   .hamburger-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 36px;
-    height: 36px;
-    background: none;
-    border: none;
-    color: var(--text-secondary);
-    cursor: pointer;
-    border-radius: var(--radius-md);
-    margin-right: 8px;
-    flex-shrink: 0;
+    display: flex; align-items: center; justify-content: center;
+    width: 36px; height: 36px; background: none; border: none;
+    color: var(--text-secondary); cursor: pointer; border-radius: var(--radius-md);
+    margin-right: 8px; flex-shrink: 0;
   }
   .hamburger-btn:hover { background: var(--bg-overlay); color: var(--text-primary); }
 
-  /* Sidebar becomes fixed drawer */
   .sidebar {
-    position: fixed !important;
-    left: -240px !important;
-    top: 0;
-    height: 100vh;
-    width: 240px !important;
-    overflow-y: auto;
-    overflow-x: hidden;
-    z-index: 100;
+    position: fixed !important; left: -240px !important; top: 0; height: 100vh;
+    width: 240px !important; overflow-y: auto; overflow-x: hidden; z-index: 100;
     transition: left 200ms ease-in-out;
   }
   .sidebar.open { left: 0 !important; }
-  /* Restore all hidden elements inside drawer */
-  .sidebar .brand-copy,
-  .sidebar .sidebar-source-count,
-  .sidebar .nav-item-label,
-  .sidebar .nav-section-label,
-  .sidebar .sidebar-bottom { display: revert; }
+  .sidebar .brand-copy, .sidebar .sidebar-source-count, .sidebar .nav-item-label,
+  .sidebar .nav-section-label, .sidebar .sidebar-bottom { display: revert; }
   .sidebar .nav-item { padding: 8px 12px; justify-content: flex-start; }
 
   .main { margin-left: 0 !important; width: 100%; }
-
   .app-shell { display: block; }
 
-  /* Header collapses — hide timestamp pills, keep alert badge */
-  .header-bar {
-    height: auto;
-    min-height: 44px;
-    padding: 8px 16px;
-    flex-wrap: wrap;
-    gap: 6px;
-    flex-direction: row;
-    align-items: center;
-  }
+  .header-bar { height: auto; min-height: 44px; padding: 8px 16px; flex-wrap: wrap; gap: 6px; }
   .header-left { flex-direction: row; align-items: center; gap: 0; }
   .header-tagline { display: none; }
   #generated-at, #last-refreshed { display: none; }
 
-  /* Content */
-  .content-wrap { padding: 16px; }
+  .content-wrap { padding: 16px; padding-bottom: 60px; /* room for command bar */ }
   .kpi-grid { gap: 8px; }
-
-  /* Touch targets */
   .nav-item { min-height: 44px; }
   .btn { min-height: 44px; }
+  .btn-sm { min-height: 36px; }
   .pill, .badge, .tag { min-height: 28px; }
-
-  /* Table horizontal scroll */
   .table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
 
-
-  /* Kanban: hide all columns, show tabs */
   .kanban-board { display: block; }
   .kanban-column { display: none; }
   .kanban-column.active { display: block; }
   .kanban-tabs {
-    display: flex;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    gap: 0;
-    border-bottom: 1px solid var(--border-default);
-    margin-bottom: 16px;
-    scrollbar-width: none;
+    display: flex; overflow-x: auto; -webkit-overflow-scrolling: touch; gap: 0;
+    border-bottom: 1px solid var(--border-default); margin-bottom: 16px; scrollbar-width: none;
   }
   .kanban-tabs::-webkit-scrollbar { display: none; }
   .kanban-tab {
-    padding: 8px 14px;
-    white-space: nowrap;
-    font-size: 13px;
-    font-weight: 500;
-    color: var(--text-tertiary);
-    border-bottom: 2px solid transparent;
-    background: none;
-    border-top: none;
-    border-left: none;
-    border-right: none;
-    cursor: pointer;
-    transition: color 150ms ease, border-color 150ms ease;
+    padding: 8px 14px; white-space: nowrap; font-size: 13px; font-weight: 500;
+    color: var(--text-tertiary); border-bottom: 2px solid transparent; background: none;
+    border-top: none; border-left: none; border-right: none; cursor: pointer;
   }
-  .kanban-tab.active {
-    color: var(--text-primary);
-    border-bottom-color: var(--accent);
-  }
+  .kanban-tab.active { color: var(--text-primary); border-bottom-color: var(--accent); }
   .kanban-tab:hover { color: var(--text-secondary); }
 
-  /* Usage table stacked cards */
   .usage-table thead { display: none; }
-  .usage-table tr {
-    display: block;
-    background: var(--bg-surface);
-    border: 1px solid var(--border-default);
-    border-radius: var(--radius-lg);
-    padding: 12px;
-    margin-bottom: 8px;
-  }
-  .usage-table td {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 4px 0;
-    border: none;
-    font-size: 13px;
-  }
-  .usage-table td::before {
-    content: attr(data-label);
-    font-weight: 500;
-    color: var(--text-tertiary);
-    font-size: 12px;
-    margin-right: 8px;
-  }
+  .usage-table tr { display: block; background: var(--bg-surface); border: 1px solid var(--border-default); border-radius: var(--radius-lg); padding: 12px; margin-bottom: 8px; }
+  .usage-table td { display: flex; justify-content: space-between; align-items: center; padding: 4px 0; border: none; font-size: 13px; }
+  .usage-table td::before { content: attr(data-label); font-weight: 500; color: var(--text-tertiary); font-size: 12px; margin-right: 8px; }
+
+  /* V5 KPI row wraps to 2x2 */
+  .v5-kpi-row { flex-wrap: wrap; }
+  .v5-kpi { flex: 1 1 45%; min-width: 0; }
+  .v5-kpi:nth-child(2) { border-right: none; }
+
+  /* V5 commitment title wraps */
+  .v5-commitment-title { white-space: normal; }
+  .v5-commitment-row__main { flex-wrap: wrap; }
+
+  /* V5 timeline time narrower */
+  .v5-timeline-time { flex: 0 0 70px; }
+  .v5-activity-time { flex: 0 0 80px; }
+
+  /* Mobile command bar fixed at bottom */
+  .v5-command-bar-mobile { display: flex; }
+  .sidebar-command-bar { display: none; }
 }
 
 /* ─── 800px: grid collapse ─── */
 @media (max-width: 800px) {
-  .status-banner__meta, .status-banner__footer, .current-work-item, .activity-row, .commitment-row, .delivery-history-row { flex-direction: column; align-items: flex-start; }
-  .grid-2, .grid-3, .grid-4, .approvals-grid, .agent-grid,
-  .artifacts-grid, .memory-grid, .split-grid {
-    grid-template-columns: 1fr;
-  }
-  .events-list-item { grid-template-columns: 1fr; gap: 6px; }
-  /* Problems: always stack on mobile */
-  .problem-list { flex-direction: column; }
-  .problem-item { width: 100%; }
+  .grid-2, .grid-3, .grid-4, .approvals-grid, .agent-grid, .artifacts-grid, .memory-grid, .split-grid { grid-template-columns: 1fr; }
 }
 
 /* ─── 480px: phone portrait ─── */
 @media (max-width: 480px) {
   .kpi-grid { grid-template-columns: 1fr; gap: 8px; }
-  .content-wrap { padding: 12px; }
-  .kpi-value { font-size: 28px !important; }
+  .content-wrap { padding: 12px; padding-bottom: 60px; }
   .header-title { font-size: 20px; }
-  .section-title { font-size: 18px; }
   .card { padding: 12px; }
+  .v5-hero { padding: var(--space-4); }
+  .v5-kpi__value { font-size: 18px; }
+}
+
+/* Desktop: show sidebar command bar, hide mobile one */
+@media (min-width: 769px) {
+  .v5-command-bar-mobile { display: none; }
 }


### PR DESCRIPTION
## Summary

Full V5 redesign implementing the UX PRD from #2:

- **AI-powered Home view** — single-scroll experience with AI summary hero, KPI row, commitments widget, active work, merged needs-attention section, activity timeline, morning digest
- **New server endpoints** — `GET /api/summary` (AI summaries with 5min cache, pluggable providers, template fallback) and `POST /api/nudge` (fire-and-forget instruction system)
- **Navigation simplified** — 9 views reduced to 5: Home, Work, Activity (merged events/artifacts/intel), Agents, Settings (merged schedule/usage/system)
- **Full actionability** — inline approve/reject with notes, snooze 24h, nudge buttons, quick command bar, commitment actions
- **Mobile-first** — responsive at 390px/768px/1200px+, pull-to-refresh, sticky command bar, 2x2 KPI grid on phone

## Test plan

- [ ] Verify Home view renders correctly on mobile (390px), tablet (768px), and desktop (1200px+)
- [ ] Test AI summary loads asynchronously and skeleton shimmer shows during load
- [ ] Test fallback summary appears when `MC_AI_KEY` is not set
- [ ] Test `POST /api/nudge` writes to `out/nudges/YYYY-MM-DD.jsonl`
- [ ] Test approval inline actions (approve/reject with optional notes)
- [ ] Test problem snooze persists in localStorage for 24h
- [ ] Test morning digest appears after 8+ hour absence and dismisses correctly
- [ ] Test quick command bar sends nudges (mobile bottom bar + desktop sidebar)
- [ ] Test pull-to-refresh on mobile
- [ ] Test navigation between all 5 views
- [ ] Test Activity view filter tabs (All/Events/Artifacts/Memory)
- [ ] Test Settings view tabs (Spend/Schedule/System)
- [ ] Verify commitment tap-to-expand shows detail + action buttons
- [ ] Verify "needs me" pulse stops after ~30 seconds

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)